### PR TITLE
Convert Transactions into Plain-English Explanations

### DIFF
--- a/packages/core/src/handlers/tx.rs
+++ b/packages/core/src/handlers/tx.rs
@@ -1,0 +1,21 @@
+use axum::{extract::Path, Json};
+use crate::models::transaction::{Operation, Transaction};
+use crate::services::explain::TxResponse;
+
+pub async fn get_transaction(Path(hash): Path<String>) -> Json<TxResponse> {
+    // Mocked data for now (later you can fetch from Horizon API)
+    let tx = Transaction {
+        hash: hash.clone(),
+        source_account: "Alice".into(),
+        operations: vec![
+            Operation::Payment {
+                from: "Alice".into(),
+                to: "Bob".into(),
+                amount: "50".into(),
+                asset: "XLM".into(),
+            }
+        ],
+    };
+
+    Json(TxResponse::from(tx))
+}

--- a/packages/core/src/models/transaction.rs
+++ b/packages/core/src/models/transaction.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Operation {
+    #[serde(rename = "payment")]
+    Payment {
+        from: String,
+        to: String,
+        amount: String,
+        asset: String,
+    },
+    #[serde(rename = "create_account")]
+    CreateAccount {
+        funder: String,
+        new_account: String,
+        starting_balance: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Transaction {
+    pub hash: String,
+    pub source_account: String,
+    pub operations: Vec<Operation>,
+}

--- a/packages/core/src/routes.rs
+++ b/packages/core/src/routes.rs
@@ -1,0 +1,7 @@
+use axum::{routing::get, Router};
+use crate::handlers::tx::get_transaction;
+
+pub fn create_routes() -> Router {
+    Router::new()
+        .route("/tx/:hash", get(get_transaction))
+}

--- a/packages/core/src/services/explain.rs
+++ b/packages/core/src/services/explain.rs
@@ -1,0 +1,28 @@
+use crate::models::transaction::{Operation, Transaction};
+use serde::Serialize;
+
+impl Operation {
+    pub fn explain(&self) -> String {
+        match self {
+            Operation::Payment { from, to, amount, asset } => {
+                format!("{} sent {} {} to {}", from, amount, asset, to)
+            }
+            Operation::CreateAccount { funder, new_account, starting_balance } => {
+                format!("New account {} created by {} with {} XLM", new_account, funder, starting_balance)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct TxResponse {
+    pub raw: Transaction,
+    pub explained: Vec<String>,
+}
+
+impl From<Transaction> for TxResponse {
+    fn from(tx: Transaction) -> Self {
+        let explained = tx.operations.iter().map(|op| op.explain()).collect();
+        TxResponse { raw: tx, explained }
+    }
+}


### PR DESCRIPTION
closes #4 

This PR introduces functionality to **convert structured Stellar transaction data into human-readable explanations**. The new `/tx/:hash` endpoint now returns both the raw transaction data and an explained version in plain English.

### 🔨 Changes Implemented

* **Models**

  * Added `Transaction` and `Operation` models under `src/models/transaction.rs` to represent different Stellar operations (`Payment`, `CreateAccount`).
* **Services**

  * Added `explain.rs` under `src/services/` to handle conversion of operations into English explanations.
  * Implemented `TxResponse` struct to wrap both raw data and explained text.
* **Handlers**

  * Created `get_transaction` handler in `src/handlers/tx.rs` to return transaction response.
  * Currently returns mocked transaction data for testing.
* **Routes**

  * Registered `/tx/:hash` endpoint in `src/routes.rs`.
* **Main**

  * Bootstrapped server in `main.rs` with Axum and mounted routes.

### ✅ Example Response

**Request**

```
GET /tx/abc123
```

**Response**

```json
{
  "raw": {
    "hash": "abc123",
    "source_account": "Alice",
    "operations": [
      {
        "type": "payment",
        "from": "Alice",
        "to": "Bob",
        "amount": "50",
        "asset": "XLM"
      }
    ]
  },
  "explained": [
    "Alice sent 50 XLM to Bob"
  ]
}
```

### 📌 Notes

* Currently supports **2 operation types**:

  * Payment → `"Alice sent 50 XLM to Bob"`
  * CreateAccount → `"New account Bob created by Alice with 2 XLM"`
* Uses **mock data** for now. Next step will be integrating Horizon API to fetch real transaction details.

### 🎯 Next Steps (Future PRs)

* Add support for more Stellar operation types (e.g., ManageOffer, PathPayment).
* Connect `/tx/:hash` to real Horizon API data.
* Add unit tests for `explain.rs`.