### PR TITLE
Parse Stellar Transactions into Structured Rust Types

### DIFF
--- a/packages/core/src/models/parse.rs
+++ b/packages/core/src/models/parse.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+
+/// Base transaction type
+#[derive(Debug, Deserialize)]
+pub struct Transaction {
+    pub id: String,
+    pub successful: bool,
+    pub source_account: String,
+    pub fee_charged: String,
+    pub operation_count: u32,
+    pub envelope_xdr: String,
+}
+
+/// Payment operation
+#[derive(Debug, Deserialize)]
+pub struct Payment {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub from: String,
+    pub to: String,
+    pub asset_type: String,
+    pub amount: String,
+}
+
+/// Account creation operation
+#[derive(Debug, Deserialize)]
+pub struct AccountCreation {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub funder: String,
+    pub account: String,
+    pub starting_balance: String,
+}

--- a/packages/core/src/routes/tx.rs
+++ b/packages/core/src/routes/tx.rs
@@ -1,0 +1,42 @@
+use actix_web::{get, web, HttpResponse};
+use crate::services::horizon_parser::{parse_transaction, parse_operation};
+
+#[get("/tx/{hash}")]
+async fn get_transaction(hash: web::Path<String>) -> HttpResponse {
+    // Normally you'd fetch from Horizon API here
+    // For now, assume we have a JSON response (mocked)
+    let mock_json = r#"
+    {
+        "id": "abcdef12345",
+        "successful": true,
+        "source_account": "GABC...",
+        "fee_charged": "100",
+        "operation_count": 1,
+        "envelope_xdr": "AAAA..."
+    }
+    "#;
+
+    match parse_transaction(mock_json) {
+        Ok(tx) => {
+            println!("Parsed Transaction: {:?}", tx);
+
+            // Mock operation JSON
+            let mock_op_json = r#"
+            {
+                "type": "payment",
+                "from": "GABC...",
+                "to": "GXYZ...",
+                "asset_type": "native",
+                "amount": "50.0"
+            }
+            "#;
+
+            if let Some(op_log) = parse_operation(mock_op_json) {
+                println!("Parsed Operation: {}", op_log);
+            }
+
+            HttpResponse::Ok().json(tx)
+        }
+        Err(e) => HttpResponse::InternalServerError().body(format!("Parse error: {}", e)),
+    }
+}

--- a/packages/core/src/services/horizon_parser.rs
+++ b/packages/core/src/services/horizon_parser.rs
@@ -1,0 +1,23 @@
+use crate::models::transactions::{Transaction, Payment, AccountCreation};
+use serde_json::Value;
+
+pub fn parse_transaction(json_str: &str) -> Result<Transaction, serde_json::Error> {
+    serde_json::from_str::<Transaction>(json_str)
+}
+
+pub fn parse_operation(json_str: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(json_str).ok()?;
+    let op_type = v.get("type")?.as_str()?;
+
+    match op_type {
+        "payment" => {
+            let payment: Payment = serde_json::from_value(v).ok()?;
+            Some(format!("Payment: from={} to={} amount={}", payment.from, payment.to, payment.amount))
+        }
+        "create_account" => {
+            let acc: AccountCreation = serde_json::from_value(v).ok()?;
+            Some(format!("CreateAccount: funder={} account={} balance={}", acc.funder, acc.account, acc.starting_balance))
+        }
+        _ => Some(format!("Unknown operation type: {}", op_type)),
+    }
+}


### PR DESCRIPTION
closes #5

This PR introduces structured parsing of raw Horizon JSON into strongly typed Rust objects. The goal is to simplify transaction handling, improve readability, and enable easier debugging by logging meaningful transaction fields.

---

## ✅ Changes Made

* Added **transaction models** (`Transaction`, `Payment`, `AccountCreation`) in `src/models/transactions.rs`.
* Implemented **Horizon JSON parser** in `src/services/horizon_parser.rs` to deserialize raw JSON into Rust structs.
* Created **transaction route** in `src/routes/tx.rs` that:

  * Accepts a transaction hash.
  * Parses mocked Horizon JSON.
  * Logs structured transaction and operation details.
  * Returns parsed transaction data as JSON.
* Updated `src/main.rs` to register the `/tx/{hash}` route with Actix Web.

---

## 🎯 Acceptance Criteria

* Running `/tx/{hash}` returns structured JSON response of the transaction.
* Logs include parsed fields such as:

  * `source_account`
  * `destination`
  * `amount`
  * `operation type`

---

## 🧪 Testing

* Start the server with `cargo run`.
* Visit `http://localhost:8080/tx/abcdef12345`.
* Confirm the following:

  * Parsed transaction fields are logged in the console.
  * Structured transaction JSON is returned in the browser.