### PR TITLE
AppError to report invalid transaction hash and Horizon Error

### DIFF
--- a/packages/core/src/errors/app_error.rs
+++ b/packages/core/src/errors/app_error.rs
@@ -14,6 +14,8 @@ pub struct ErrorResponse {
 pub enum AppError {
     NotFound(String),
     Internal(String),
+    InvalidInput(String),
+    HorizonError,
 }
 
 impl IntoResponse for AppError {
@@ -26,6 +28,18 @@ impl IntoResponse for AppError {
             AppError::Internal(msg) => {
                 let body = Json(ErrorResponse { error: msg });
                 (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
+            }
+            AppError::InvalidInput(msg) => {
+                let body = Json(ErrorResponse {
+                    error: format!("Invalid Transaction Hash: {msg}"),
+                });
+                (StatusCode::BAD_REQUEST, body).into_response()
+            }
+            AppError::HorizonError => {
+                let body = Json(ErrorResponse {
+                    error: "The transaction failed when submitted to the stellar network.",
+                });
+                (StatusCode::BAD_REQUEST, body).into_response()
             }
         }
     }


### PR DESCRIPTION
closes #13 

`AppError` Enum now contains error variants for invalid hash input and horizon error, and these error variants implement the `IntoResponse` trait reporting the error message and status code.