### PR TITLE
Add transaction explanation functionality with operation type support

### DIFF
--- a/packages/core/src/models/explain.rs
+++ b/packages/core/src/models/explain.rs
@@ -10,6 +10,18 @@ impl Operation {
             Operation::CreateAccount { funder, new_account, starting_balance } => {
                 format!("New account {} created by {} with {} XLM", new_account, funder, starting_balance)
             }
+            Operation::ChangeTrust { account, asset, limit } => {
+                format!("{} established trustline for {} with limit {}", account, asset, limit)
+            }
+            Operation::ManageOffer { seller, selling, buying, amount, price } => {
+                format!("{} placed/updated offer: selling {} {} for {} {} (price {})",
+                    seller, amount, selling, buying, amount, price)
+            }
+            Operation::PathPayment { from, to, dest_asset, dest_amount, path } => {
+                format!("{} sent {} {} to {} via path {:?}",
+                    from, dest_amount, dest_asset, to, path)
+            }
+            _ => "Unknown operation".to_string(), // fallback
         }
     }
 }

--- a/packages/core/src/models/mod.rs
+++ b/packages/core/src/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod parse;
+pub mod transaction;
+pub mod explain;

--- a/packages/core/src/models/transaction.rs
+++ b/packages/core/src/models/transaction.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(tag = "type")]
 pub enum Operation {
     #[serde(rename = "payment")]
@@ -15,6 +15,28 @@ pub enum Operation {
         funder: String,
         new_account: String,
         starting_balance: String,
+    },
+    #[serde(rename = "change_trust")]
+    ChangeTrust {
+        account: String,
+        asset: String,
+        limit: String,
+    },
+    #[serde(rename = "manage_offer")]
+    ManageOffer {
+        seller: String,
+        selling: String,
+        buying: String,
+        amount: String,
+        price: String,
+    },
+    #[serde(rename = "path_payment")]
+    PathPayment {
+        from: String,
+        to: String,
+        dest_asset: String,
+        dest_amount: String,
+        path: Vec<String>,
     },
 }
 


### PR DESCRIPTION
SUMMARY:
- Import models module and add Transaction/TxResponse types for structured data handling
- Implement tx_handler endpoint that returns transactions with human-readable explanations
- Extend Operation enum with ChangeTrust, ManageOffer, and PathPayment variants
- Update fetch_transaction to return typed Transaction instead of generic JSON Value
- Clean up duplicate imports and formatting inconsistencies
- Add models module structure with parse, transaction, and explain submodules