### PR TITLE
feat(core): add CORS middleware to allow requests from Next.js dev server

### DIFF
--- a/packages/core/Cargo.lock
+++ b/packages/core/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -14,6 +14,8 @@ dotenvy = "0.15"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+tower-http = { version = "0.6", features = ["cors"] }
+
 
 [dev-dependencies]
 httpmock = "0.7"

--- a/packages/core/src/main.rs
+++ b/packages/core/src/main.rs
@@ -10,25 +10,48 @@ use tracing::info;
 use tokio::net::TcpListener;
 use std::sync::Arc;
 use std::env;
+use tower_http::cors::{CorsLayer, AllowOrigin};
+use axum::http::{HeaderValue, Method, header};
 
 use crate::services::horizon::HorizonClient;
 
 #[tokio::main]
 async fn main() {
+    // Load .env file if present
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt().init();
 
+    // ── Horizon URL ───────
     let horizon_url = env::var("HORIZON_URL")
         .unwrap_or_else(|_| "https://horizon-testnet.stellar.org".to_string());
-    
+
     info!("Using Horizon URL: {}", horizon_url);
 
+    // ── CORS ─────────
+    // Reads CORS_ORIGIN from .env (e.g. http://localhost:3000).
+    // Falls back to localhost:3000 for local development.
+    let cors_origin = env::var("CORS_ORIGIN")
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+
+    info!("Allowing CORS from: {}", cors_origin);
+
+    let allowed_origin: HeaderValue = cors_origin
+        .parse()
+        .expect("CORS_ORIGIN is not a valid HTTP header value");
+
+    let cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::exact(allowed_origin))
+        .allow_methods([Method::GET, Method::OPTIONS])
+        .allow_headers([header::CONTENT_TYPE, header::ACCEPT]);
+
+    // ── App ────────
     let horizon_client = Arc::new(HorizonClient::new(horizon_url));
 
     let app = Router::new()
         .route("/health", axum::routing::get(|| async { "ok" }))
         .route("/tx/:hash", axum::routing::get(routes::tx::get_tx_explanation))
-        .with_state(horizon_client);
+        .with_state(horizon_client)
+        .layer(cors);  // CORS layer goes last — it wraps the entire router
 
     let addr = "0.0.0.0:4000";
     info!("Stellar Explain backend running on {}", addr);


### PR DESCRIPTION
## PR 
Adds `tower-http` CORS middleware to the Axum router so the Next.js frontend (running on `localhost:3000`) can make requests to the Rust backend (`localhost:4000`) without being blocked by the browser.
closes #84 

## Changes
- `Cargo.toml` — added `tower-http = { version = "0.6", features = ["cors"] }`
- `src/main.rs` — configured `CorsLayer` with allowed origin, methods (`GET`, `OPTIONS`), and headers (`content-type`, `accept`)
- `.env` — added `CORS_ORIGIN` variable (defaults to `http://localhost:3000`)

## How it was tested

**1. Health check**
```bash
curl http://localhost:4000/health
# → ok
```

**2. Real testnet transaction**
```bash
curl http://localhost:4000/tx/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020
# → TransactionExplanation JSON with 2 payments, 8 skipped operations
```

**3. CORS preflight**
```bash
curl -v \
  -H "Origin: http://localhost:3000" \
  -H "Access-Control-Request-Method: GET" \
  -X OPTIONS \
  http://localhost:4000/tx/b9d0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9c9020
```
Response confirmed:
```
access-control-allow-origin: http://localhost:3000
access-control-allow-methods: GET,OPTIONS
access-control-allow-headers: content-type,accept
```

## Notes
- `CORS_ORIGIN` is read from `.env` at startup — change it to match your frontend URL in production
- Closes INT #84 