### PR TITLE
fix(core): remove duplicate Transaction struct and use AppError in routes

### DIFF
--- a/packages/core/src/models/operation.rs
+++ b/packages/core/src/models/operation.rs
@@ -2,23 +2,6 @@
 //!
 //! Internal representation of Stellar operations, independent of Horizon JSON.
 
-use crate::models::memo::Memo;
-
-
-#[derive(Debug, Clone)]
-pub struct Transaction {
-    pub hash: String,
-    pub successful: bool,
-    pub fee_charged: u64,
-    pub operations: Vec<Operation>,
-    pub memo: Memo,
-
-}
-
-
-
-
-
 use serde::{Deserialize, Serialize};
 
 /// Represents a Stellar operation.

--- a/packages/core/src/routes/tx.rs
+++ b/packages/core/src/routes/tx.rs
@@ -1,39 +1,31 @@
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
     Json,
 };
 use std::sync::Arc;
 
 use crate::{
+    errors::AppError,
     explain::transaction::{explain_transaction, TransactionExplanation},
     services::{explain::map_transaction_to_domain, horizon::HorizonClient},
-    errors::HorizonError,
 };
 
 pub async fn get_tx_explanation(
     Path(hash): Path<String>,
     State(horizon_client): State<Arc<HorizonClient>>,
-) -> Result<Json<TransactionExplanation>, (StatusCode, String)> {
+) -> Result<Json<TransactionExplanation>, AppError> {
     let tx_future = horizon_client.fetch_transaction(&hash);
     let ops_future = horizon_client.fetch_operations(&hash);
 
     let (tx_res, ops_res) = tokio::join!(tx_future, ops_future);
 
-    let tx = tx_res.map_err(map_horizon_error)?;
-    let ops = ops_res.map_err(map_horizon_error)?;
+    // HorizonError converts to AppError via the From impl in errors.rs
+    let tx = tx_res.map_err(AppError::from)?;
+    let ops = ops_res.map_err(AppError::from)?;
 
     let domain_tx = map_transaction_to_domain(tx, ops);
 
-    match explain_transaction(&domain_tx) {
-        Ok(explanation) => Ok(Json(explanation)),
-        Err(e) => Err((StatusCode::BAD_REQUEST, e.to_string())),
-    }
-}
-
-fn map_horizon_error(err: HorizonError) -> (StatusCode, String) {
-    match err {
-        HorizonError::TransactionNotFound => (StatusCode::NOT_FOUND, "Transaction not found".to_string()),
-        _ => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error".to_string()),
-    }
+    explain_transaction(&domain_tx)
+        .map(Json)
+        .map_err(|e| AppError::BadRequest(e.to_string()))
 }


### PR DESCRIPTION
 # **PR description:**
```

Fixes two structural issues in the backend that were blocking clean 
compilation and proper error responses.

## Changes

### Fix #1 — Remove duplicate Transaction struct (models/operation.rs)
- Removed the conflicting Transaction struct at the top of operation.rs
- The canonical Transaction lives in models/transaction.rs with the 
  correct memo: Option<Memo> field
- Removed the unused `use crate::models::memo::Memo` import that came with it

### Fix #2 — Use AppError in routes/tx.rs
- Replaced raw (StatusCode, String) return types with AppError
- Removed the local map_horizon_error() function — HorizonError already 
  converts to AppError via From impl in errors.rs
- Route now returns structured JSON errors automatically

## How it was tested
cargo build — compiled cleanly

Not-found case returns structured JSON:
curl http://localhost:4000/tx/000...000
→ {"error":{"code":"NOT_FOUND","message":"Transaction not found on the Stellar network."}}

Closes #114 
closes #113 