### PR TITLE
fix(core): deserialize memo fields from Horizon and wire network config into startup

### DIFF
--- a/packages/core/src/services/explain.rs
+++ b/packages/core/src/services/explain.rs
@@ -1,21 +1,92 @@
-use crate::models::transaction::Transaction;
+use crate::models::memo::Memo;
 use crate::models::operation::Operation;
-use crate::services::horizon::{HorizonTransaction, HorizonOperation};
+use crate::models::transaction::Transaction;
+use crate::services::horizon::{HorizonOperation, HorizonTransaction};
 
 pub fn map_transaction_to_domain(
     tx: HorizonTransaction,
     operations: Vec<HorizonOperation>,
 ) -> Transaction {
-    let ops = operations
-        .into_iter()
-        .map(Operation::from)
-        .collect();
+    let ops = operations.into_iter().map(Operation::from).collect();
 
-    Transaction::new(
-        tx.hash,
-        tx.successful,
-        tx.fee_charged.parse().unwrap_or(0),
-        ops,
-        None,
-    )
+    // Map memo fields from Horizon into the domain Memo model.
+    // Horizon always returns memo_type — it's "none" when there is no memo.
+    // The memo value itself is only present for non-none memo types.
+    let memo = map_memo(tx.memo_type.as_deref(), tx.memo.as_deref());
+
+    Transaction::new(tx.hash, tx.successful, tx.fee_charged.parse().unwrap_or(0), ops, memo)
+}
+
+/// Converts raw Horizon memo fields into a domain Memo.
+///
+/// Horizon memo types: "none", "text", "id", "hash", "return"
+fn map_memo(memo_type: Option<&str>, memo_value: Option<&str>) -> Option<Memo> {
+    match memo_type {
+        None | Some("none") => None,
+        Some("text") => {
+            memo_value.and_then(|v| Memo::text(v))
+        }
+        Some("id") => {
+            memo_value
+                .and_then(|v| v.parse::<u64>().ok())
+                .map(Memo::id)
+        }
+        Some("hash") => {
+            memo_value.map(|v| Memo::hash(v))
+        }
+        Some("return") => {
+            memo_value.map(|v| Memo::return_hash(v))
+        }
+        // Unknown memo type — treat as no memo rather than crashing
+        Some(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_map_memo_none_type() {
+        assert_eq!(map_memo(Some("none"), None), None);
+    }
+
+    #[test]
+    fn test_map_memo_missing_type() {
+        assert_eq!(map_memo(None, None), None);
+    }
+
+    #[test]
+    fn test_map_memo_text() {
+        let memo = map_memo(Some("text"), Some("Hello Stellar"));
+        assert!(memo.is_some());
+        assert_eq!(memo.unwrap().memo_type(), "text");
+    }
+
+    #[test]
+    fn test_map_memo_id() {
+        let memo = map_memo(Some("id"), Some("12345"));
+        assert!(memo.is_some());
+        assert_eq!(memo.unwrap().memo_type(), "id");
+    }
+
+    #[test]
+    fn test_map_memo_hash() {
+        let memo = map_memo(Some("hash"), Some("abc123deadbeef"));
+        assert!(memo.is_some());
+        assert_eq!(memo.unwrap().memo_type(), "hash");
+    }
+
+    #[test]
+    fn test_map_memo_return() {
+        let memo = map_memo(Some("return"), Some("abc123deadbeef"));
+        assert!(memo.is_some());
+        assert_eq!(memo.unwrap().memo_type(), "return");
+    }
+
+    #[test]
+    fn test_map_memo_unknown_type() {
+        // Unknown types should degrade gracefully, not crash
+        assert_eq!(map_memo(Some("unknown_future_type"), Some("value")), None);
+    }
 }

--- a/packages/core/src/services/horizon.rs
+++ b/packages/core/src/services/horizon.rs
@@ -1,23 +1,30 @@
 use reqwest::Client;
 use serde::Deserialize;
-// use crate::config::network::StellarNetwork;t
 
 use crate::errors::HorizonError;
 
+/// Raw transaction response from the Horizon API.
+///
+/// Captures all fields needed for domain mapping including all 5 memo types.
 #[derive(Debug, Deserialize)]
 pub struct HorizonTransaction {
     pub hash: String,
     pub successful: bool,
     pub fee_charged: String,
+
+    // Memo fields — all optional since not every transaction has a memo
+    // memo_type is always present but can be "none"
+    pub memo_type: Option<String>,
+
+    // memo is only present when memo_type is not "none"
+    pub memo: Option<String>,
 }
 
 #[derive(Clone)]
 pub struct HorizonClient {
     client: Client,
     base_url: String,
-
 }
-
 
 impl HorizonClient {
     pub fn new(base_url: impl Into<String>) -> Self {
@@ -26,13 +33,6 @@ impl HorizonClient {
             base_url: base_url.into(),
         }
     }
-
-    // pub fn from_network(network: StellarNetwork) -> Self {
-    //     Self {
-    //         client: Client::new(),
-    //         base_url: network.horizon_url().to_string(),
-    //     }
-    // }
 
     pub async fn fetch_transaction(
         &self,


### PR DESCRIPTION

## Pull Request Description
Fixes two issues: memo data was being silently dropped from every 
Horizon response, and the config/network.rs module was fully implemented 
but never used.

## Changes

### Fix #111  — Deserialize memo fields from Horizon (services/horizon.rs + services/explain.rs)
- Added memo_type and memo fields to HorizonTransaction so they are no 
  longer silently dropped from Horizon API responses
- Added map_memo() in services/explain.rs that converts raw Horizon memo 
  fields into the domain Memo model
- Handles all 5 Horizon memo types: none, text, id, hash, return
- Unknown future memo types degrade gracefully to None

### Fix #110  — Wire config/network.rs into startup (main.rs)
- Replaced raw env::var("HORIZON_URL") with StellarNetwork::from_env()
- Network is now resolved from STELLAR_NETWORK env var automatically
- HORIZON_URL still works as an explicit override for custom nodes
- Startup now logs the resolved network: Network: Testnet

## How it was tested
cargo test — 60 + 56 + 16 doc-tests passed, 0 failed

Closes #111 , Closes #110 