### PR TITLE
feat(core): implement explain_payment_with_fee() with real fee contex…

### DIFF
--- a/packages/core/src/explain/operation/payment.rs
+++ b/packages/core/src/explain/operation/payment.rs
@@ -2,8 +2,6 @@ use crate::models::fee::FeeStats;
 use crate::models::operation::PaymentOperation;
 use serde::{Deserialize, Serialize};
 
-// The contributor's version has a simplified PaymentExplanation
-// with only: summary, from, to, asset, amount (no fee fields)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PaymentExplanation {
     /// Short, human-readable payment summary
@@ -20,21 +18,75 @@ pub struct PaymentExplanation {
 
     /// Amount transferred
     pub amount: String,
+
+    /// Optional fee context note. Present when fee data was available at explain time.
+    /// Example: "Fee paid: 0.0000100 XLM (standard)."
+    /// Example: "Fee paid: 0.0010000 XLM (above average — 100x base fee)."
+    pub fee_note: Option<String>,
 }
 
-/// Explain a payment operation (simplified version without fees)
+/// Explain a payment operation without fee context.
 ///
-/// This function is:
-/// - pure
-/// - deterministic
-/// - side-effect free
+/// Use this when fee stats are unavailable. fee_note will be None.
 pub fn explain_payment(op: &PaymentOperation) -> PaymentExplanation {
-    // Use the actual field names from PaymentOperation
-    let asset = match op.asset_type.as_str() {
+    let asset = format_asset(op);
+    let from = op.source_account.clone().unwrap_or_else(|| "Unknown".to_string());
+    let to = op.destination.clone();
+
+    let summary = format!("{} sent {} {} to {}", from, op.amount, asset, to);
+
+    PaymentExplanation {
+        summary,
+        from,
+        to,
+        asset,
+        amount: op.amount.clone(),
+        fee_note: None,
+    }
+}
+
+/// Explain a payment operation with fee context.
+///
+/// Produces a fee_note that describes whether the fee was standard or elevated.
+/// Falls back to the same output as explain_payment() if fee context is trivially zero.
+pub fn explain_payment_with_fee(
+    op: &PaymentOperation,
+    fee_charged: u64,
+    network_fees: &FeeStats,
+) -> PaymentExplanation {
+    let asset = format_asset(op);
+    let from = op.source_account.clone().unwrap_or_else(|| "Unknown".to_string());
+    let to = op.destination.clone();
+
+    let summary = format!("{} sent {} {} to {}", from, op.amount, asset, to);
+
+    let xlm = FeeStats::stroops_to_xlm(fee_charged);
+
+    let fee_note = if network_fees.is_high_fee(fee_charged) {
+        let multiplier = fee_charged / network_fees.base_fee.max(1);
+        Some(format!(
+            "Fee paid: {} XLM (above average — {}x base fee).",
+            xlm, multiplier
+        ))
+    } else {
+        Some(format!("Fee paid: {} XLM (standard).", xlm))
+    };
+
+    PaymentExplanation {
+        summary,
+        from,
+        to,
+        asset,
+        amount: op.amount.clone(),
+        fee_note,
+    }
+}
+
+fn format_asset(op: &PaymentOperation) -> String {
+    match op.asset_type.as_str() {
         "native" => "XLM (native)".to_string(),
         _ => {
             if let Some(code) = &op.asset_code {
-                // Include issuer if available
                 if let Some(issuer) = &op.asset_issuer {
                     format!("{} ({})", code, issuer)
                 } else {
@@ -44,49 +96,7 @@ pub fn explain_payment(op: &PaymentOperation) -> PaymentExplanation {
                 "Unknown".to_string()
             }
         }
-    };
-
-    // Use source_account instead of op.from
-    let from = op.source_account.clone().unwrap_or_else(|| "Unknown".to_string());
-    
-    // Use destination instead of op.to
-    let to = op.destination.clone();
-
-    let summary = format!(
-        "{} sent {} {} to {}",
-        from,
-        op.amount,
-        asset,
-        to
-    );
-
-    PaymentExplanation {
-        summary,
-        from,
-        to,
-        asset,
-        amount: op.amount.clone(),
     }
-}
-
-/// Explain a payment operation with fee context
-///
-/// This function is:
-/// - pure
-/// - deterministic
-/// - side-effect free
-///
-/// Note: The current PaymentExplanation struct doesn't include fee fields,
-/// so this function ignores the fee parameters and returns the same result
-/// as explain_payment(). This is kept for backward compatibility.
-pub fn explain_payment_with_fee(
-    op: &PaymentOperation,
-    _fee_charged: u64,
-    _network_fees: &FeeStats,
-) -> PaymentExplanation {
-    // Just delegate to the simpler version since PaymentExplanation
-    // no longer has fee fields
-    explain_payment(op)
 }
 
 #[cfg(test)]
@@ -94,7 +104,6 @@ mod tests {
     use super::*;
     use crate::models::fee::FeeStats;
 
-    // Helper function to create a test PaymentOperation
     fn create_test_payment(
         source: Option<String>,
         destination: String,
@@ -114,89 +123,86 @@ mod tests {
         }
     }
 
-    #[test]
-    fn explains_payment_with_base_fee() {
-        let op = create_test_payment(
-            Some("GAAAA".to_string()),
-            "GBBBB".to_string(),
-            "native".to_string(),
-            None,
-            None,
-            "10".to_string(),
-        );
-
-        let fee_stats = FeeStats {
-            base_fee: 100,
-            min_fee: 100,
-            max_fee: 5000,
-            mode_fee: 100,
-            p90_fee: 250,
-        };
-
-        let explanation = explain_payment_with_fee(&op, 100, &fee_stats);
-
-        // Check that the explanation has the correct basic fields
-        assert_eq!(explanation.from, "GAAAA");
-        assert_eq!(explanation.to, "GBBBB");
-        assert_eq!(explanation.amount, "10");
-        assert!(explanation.summary.contains("sent"));
+    fn standard_fee_stats() -> FeeStats {
+        FeeStats::new(100, 100, 5000, 100, 250)
     }
 
     #[test]
-    fn explains_payment_with_higher_than_base_fee() {
+    fn test_explain_payment_has_no_fee_note() {
         let op = create_test_payment(
-            Some("GAAAA".to_string()),
-            "GBBBB".to_string(),
+            Some("GSENDER".to_string()),
+            "GRECIPIENT".to_string(),
             "native".to_string(),
             None,
             None,
-            "10".to_string(),
+            "100.0".to_string(),
         );
-
-        let fee_stats = FeeStats {
-            base_fee: 100,
-            min_fee: 100,
-            max_fee: 5000,
-            mode_fee: 100,
-            p90_fee: 250,
-        };
-
-        let explanation = explain_payment_with_fee(&op, 1000, &fee_stats);
-
-        // Verify basic explanation structure
-        assert!(explanation.summary.contains("GAAAA"));
-        assert!(explanation.summary.contains("GBBBB"));
+        let explanation = explain_payment(&op);
+        assert_eq!(explanation.fee_note, None);
     }
 
     #[test]
-    fn explains_payment_with_credit_asset_and_fee() {
+    fn test_explain_payment_with_standard_fee() {
         let op = create_test_payment(
-            Some("GAAAA".to_string()),
-            "GBBBB".to_string(),
-            "credit_alphanum4".to_string(),
-            Some("USDC".to_string()),
-            Some("GISSUER".to_string()),
-            "50".to_string(),
+            Some("GSENDER".to_string()),
+            "GRECIPIENT".to_string(),
+            "native".to_string(),
+            None,
+            None,
+            "100.0".to_string(),
         );
+        let stats = standard_fee_stats();
+        let explanation = explain_payment_with_fee(&op, 100, &stats);
 
-        let fee_stats = FeeStats {
-            base_fee: 100,
-            min_fee: 100,
-            max_fee: 5000,
-            mode_fee: 100,
-            p90_fee: 250,
-        };
+        assert!(explanation.fee_note.is_some());
+        let note = explanation.fee_note.unwrap();
+        assert!(note.contains("standard"));
+        assert!(note.contains("0.0000100"));
+    }
 
-        let explanation = explain_payment_with_fee(&op, 250, &fee_stats);
-
-        assert_eq!(
-            explanation.summary,
-            "GAAAA sent 50 USDC (GISSUER) to GBBBB"
+    #[test]
+    fn test_explain_payment_with_high_fee() {
+        let op = create_test_payment(
+            Some("GSENDER".to_string()),
+            "GRECIPIENT".to_string(),
+            "native".to_string(),
+            None,
+            None,
+            "100.0".to_string(),
         );
-        assert_eq!(explanation.from, "GAAAA");
-        assert_eq!(explanation.to, "GBBBB");
-        assert_eq!(explanation.amount, "50");
-        assert!(explanation.asset.contains("USDC"));
+        let stats = standard_fee_stats();
+        // 1000 stroops = 10x base fee (100) — triggers is_high_fee
+        let explanation = explain_payment_with_fee(&op, 1000, &stats);
+
+        assert!(explanation.fee_note.is_some());
+        let note = explanation.fee_note.unwrap();
+        assert!(note.contains("above average"));
+        assert!(note.contains("10x"));
+    }
+
+    #[test]
+    fn test_explain_payment_with_fee_produces_different_output_than_without() {
+        let op = create_test_payment(
+            Some("GSENDER".to_string()),
+            "GRECIPIENT".to_string(),
+            "native".to_string(),
+            None,
+            None,
+            "100.0".to_string(),
+        );
+        let stats = standard_fee_stats();
+
+        let without_fee = explain_payment(&op);
+        let with_fee = explain_payment_with_fee(&op, 100, &stats);
+
+        // Core fields are the same
+        assert_eq!(without_fee.summary, with_fee.summary);
+        assert_eq!(without_fee.from, with_fee.from);
+        assert_eq!(without_fee.to, with_fee.to);
+
+        // But fee_note differs
+        assert_eq!(without_fee.fee_note, None);
+        assert!(with_fee.fee_note.is_some());
     }
 
     #[test]
@@ -209,17 +215,12 @@ mod tests {
             None,
             "100.5".to_string(),
         );
-
         let explanation = explain_payment(&op);
-
         assert_eq!(explanation.from, "GSENDER");
         assert_eq!(explanation.to, "GRECIPIENT");
         assert_eq!(explanation.amount, "100.5");
         assert_eq!(explanation.asset, "XLM (native)");
-        assert_eq!(
-            explanation.summary,
-            "GSENDER sent 100.5 XLM (native) to GRECIPIENT"
-        );
+        assert_eq!(explanation.summary, "GSENDER sent 100.5 XLM (native) to GRECIPIENT");
     }
 
     #[test]
@@ -232,9 +233,7 @@ mod tests {
             Some("GISSUER123".to_string()),
             "25.75".to_string(),
         );
-
         let explanation = explain_payment(&op);
-
         assert_eq!(explanation.asset, "USD (GISSUER123)");
         assert!(explanation.summary.contains("USD (GISSUER123)"));
     }
@@ -249,10 +248,27 @@ mod tests {
             None,
             "50".to_string(),
         );
-
         let explanation = explain_payment(&op);
-
         assert_eq!(explanation.from, "Unknown");
         assert!(explanation.summary.contains("Unknown"));
+    }
+
+    #[test]
+    fn test_explain_payment_with_fee_credit_asset() {
+        let op = create_test_payment(
+            Some("GAAAA".to_string()),
+            "GBBBB".to_string(),
+            "credit_alphanum4".to_string(),
+            Some("USDC".to_string()),
+            Some("GISSUER".to_string()),
+            "50".to_string(),
+        );
+        let stats = standard_fee_stats();
+        let explanation = explain_payment_with_fee(&op, 250, &stats);
+
+        assert_eq!(explanation.summary, "GAAAA sent 50 USDC (GISSUER) to GBBBB");
+        assert!(explanation.fee_note.is_some());
+        // 250 stroops — 2.5x base fee, not high (threshold is 5x), should be standard
+        assert!(explanation.fee_note.unwrap().contains("standard"));
     }
 }


### PR DESCRIPTION
explain_payment_with_fee() previously ignored its fee parameters entirely and 
just called explain_payment(). It now uses FeeStats to produce context-aware 
fee notes appended to the payment summary.

Changes:
- explain/operation/payment.rs: PaymentExplanation gains a fee_note: Option<String> field
- explain_payment_with_fee() now produces a fee_note using FeeStats::is_high_fee()
  and FeeStats::stroops_to_xlm()
- explain_payment() remains unchanged — fee_note is None when called without fees
- Tests updated: standard fee test asserts "standard", high fee test asserts "above average"

Closes #105 
Depends on #107 