### PR TITLE
add GET /account/:address and /account/:address/transactions endpoints

### DIFF
--- a/packages/core/src/errors.rs
+++ b/packages/core/src/errors.rs
@@ -22,6 +22,7 @@ pub struct ErrorBody {
 pub enum HorizonError {
     NetworkError,
     TransactionNotFound,
+    AccountNotFound,
     InvalidResponse,
 }
 
@@ -89,6 +90,9 @@ impl From<HorizonError> for AppError {
                 AppError::NotFound(
                     "Transaction not found on the Stellar network.".into(),
                 )
+            }
+            HorizonError::AccountNotFound => {
+                AppError::NotFound("Account not found on the Stellar network.".into())
             }
             HorizonError::NetworkError => {
                 AppError::UpstreamFailure(

--- a/packages/core/src/explain/account.rs
+++ b/packages/core/src/explain/account.rs
@@ -1,0 +1,186 @@
+use crate::models::account::Account;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct AccountExplanation {
+    pub summary: String,
+    pub xlm_balance: String,
+    pub asset_count: usize,
+    pub signer_count: u32,
+    pub flag_descriptions: Vec<String>,
+}
+
+pub fn explain_account(account: &Account) -> AccountExplanation {
+    let xlm_balance = account
+        .balances
+        .iter()
+        .find(|b| b.asset_type == "native")
+        .map(|b| b.balance.clone())
+        .unwrap_or_else(|| "0".to_string());
+
+    let other_assets: Vec<_> = account
+        .balances
+        .iter()
+        .filter(|b| b.asset_type != "native")
+        .collect();
+
+    let asset_count = other_assets.len();
+
+    let home_domain_part = account
+        .home_domain
+        .as_deref()
+        .map(|d| format!(" and home domain {}.", d))
+        .unwrap_or_else(|| ".".to_string());
+
+    let summary = if asset_count == 0 {
+        format!(
+            "This account holds {} XLM. It has {} signer{}{}",
+            xlm_balance,
+            account.num_signers,
+            if account.num_signers == 1 { "" } else { "s" },
+            home_domain_part
+        )
+    } else {
+        format!(
+            "This account holds {} XLM and {} other asset{}. It has {} signer{}{}",
+            xlm_balance,
+            asset_count,
+            if asset_count == 1 { "" } else { "s" },
+            account.num_signers,
+            if account.num_signers == 1 { "" } else { "s" },
+            home_domain_part
+        )
+    };
+
+    let mut flag_descriptions = Vec::new();
+    if account.flags.auth_required {
+        flag_descriptions.push(
+            "Auth required: accounts must be authorized before holding this asset.".to_string(),
+        );
+    }
+    if account.flags.auth_revocable {
+        flag_descriptions.push(
+            "Auth revocable: the issuer can freeze this asset in a holder's account.".to_string(),
+        );
+    }
+    if account.flags.auth_immutable {
+        flag_descriptions.push(
+            "Auth immutable: account flags and signers can no longer be changed.".to_string(),
+        );
+    }
+    if account.flags.auth_clawback_enabled {
+        flag_descriptions.push(
+            "Clawback enabled: the issuer can claw back this asset from holders.".to_string(),
+        );
+    }
+
+    AccountExplanation {
+        summary,
+        xlm_balance,
+        asset_count,
+        signer_count: account.num_signers,
+        flag_descriptions,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::account::{AccountFlags, Balance};
+
+    fn mock_account(xlm: &str, extra_assets: usize, num_signers: u32, home_domain: Option<&str>) -> Account {
+        let mut balances = vec![Balance {
+            asset_type: "native".to_string(),
+            asset_code: None,
+            asset_issuer: None,
+            balance: xlm.to_string(),
+        }];
+        for i in 0..extra_assets {
+            balances.push(Balance {
+                asset_type: "credit_alphanum4".to_string(),
+                asset_code: Some(format!("ASSET{}", i)),
+                asset_issuer: Some("GISSUER".to_string()),
+                balance: "10.0000000".to_string(),
+            });
+        }
+        Account {
+            id: "GTEST".to_string(),
+            account_id: "GTEST".to_string(),
+            sequence: "1234".to_string(),
+            num_signers,
+            balances,
+            flags: AccountFlags {
+                auth_required: false,
+                auth_revocable: false,
+                auth_immutable: false,
+                auth_clawback_enabled: false,
+            },
+            home_domain: home_domain.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_summary_no_extra_assets() {
+        let account = mock_account("100.5000000", 0, 1, None);
+        let explanation = explain_account(&account);
+        assert_eq!(explanation.asset_count, 0);
+        assert_eq!(explanation.signer_count, 1);
+        assert!(explanation.summary.contains("100.5000000 XLM"));
+        assert!(!explanation.summary.contains("other asset"));
+    }
+
+    #[test]
+    fn test_summary_with_extra_assets_and_home_domain() {
+        let account = mock_account("104.5000000", 2, 1, Some("stellar.org"));
+        let explanation = explain_account(&account);
+        assert_eq!(explanation.asset_count, 2);
+        assert!(explanation.summary.contains("104.5000000 XLM"));
+        assert!(explanation.summary.contains("2 other assets"));
+        assert!(explanation.summary.contains("stellar.org"));
+    }
+
+    #[test]
+    fn test_xlm_balance_extraction() {
+        let account = mock_account("50.0000000", 1, 2, None);
+        let explanation = explain_account(&account);
+        assert_eq!(explanation.xlm_balance, "50.0000000");
+    }
+
+    #[test]
+    fn test_flag_descriptions() {
+        let mut account = mock_account("0.0", 0, 1, None);
+        account.flags.auth_required = true;
+        account.flags.auth_revocable = true;
+        let explanation = explain_account(&account);
+        assert_eq!(explanation.flag_descriptions.len(), 2);
+        assert!(explanation.flag_descriptions[0].contains("Auth required"));
+        assert!(explanation.flag_descriptions[1].contains("Auth revocable"));
+    }
+
+    #[test]
+    fn test_no_flags() {
+        let account = mock_account("0.0", 0, 1, None);
+        let explanation = explain_account(&account);
+        assert!(explanation.flag_descriptions.is_empty());
+    }
+
+    #[test]
+    fn test_missing_xlm_balance_defaults_to_zero() {
+        let account = Account {
+            id: "G1".to_string(),
+            account_id: "G1".to_string(),
+            sequence: "0".to_string(),
+            num_signers: 1,
+            balances: vec![],
+            flags: AccountFlags {
+                auth_required: false,
+                auth_revocable: false,
+                auth_immutable: false,
+                auth_clawback_enabled: false,
+            },
+            home_domain: None,
+        };
+        let explanation = explain_account(&account);
+        assert_eq!(explanation.xlm_balance, "0");
+    }
+}

--- a/packages/core/src/explain/mod.rs
+++ b/packages/core/src/explain/mod.rs
@@ -5,3 +5,4 @@
 pub mod operation;
 pub mod transaction;
 pub mod memo;
+pub mod account;

--- a/packages/core/src/models/account.rs
+++ b/packages/core/src/models/account.rs
@@ -1,0 +1,31 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Balance {
+    pub asset_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_issuer: Option<String>,
+    pub balance: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AccountFlags {
+    pub auth_required: bool,
+    pub auth_revocable: bool,
+    pub auth_immutable: bool,
+    pub auth_clawback_enabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Account {
+    pub id: String,
+    pub account_id: String,
+    pub sequence: String,
+    pub num_signers: u32,
+    pub balances: Vec<Balance>,
+    pub flags: AccountFlags,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub home_domain: Option<String>,
+}

--- a/packages/core/src/models/mod.rs
+++ b/packages/core/src/models/mod.rs
@@ -2,3 +2,4 @@ pub mod operation;
 pub mod transaction;
 pub mod fee;
 pub mod memo;
+pub mod account;

--- a/packages/core/src/routes/account.rs
+++ b/packages/core/src/routes/account.rs
@@ -1,0 +1,156 @@
+use axum::{
+    extract::{Path, Query, State},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::{errors::AppError, services::horizon::HorizonClient};
+
+#[derive(Debug, Deserialize)]
+pub struct AccountTransactionsQuery {
+    pub limit: Option<u32>,
+    pub cursor: Option<String>,
+    pub order: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransactionSummary {
+    pub hash: String,
+    pub created_at: String,
+    pub successful: bool,
+    pub operation_count: u32,
+    pub memo: Option<String>,
+    pub summary: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PaginatedResponse<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<String>,
+    pub prev_cursor: Option<String>,
+}
+
+pub async fn get_account_transactions(
+    Path(address): Path<String>,
+    Query(params): Query<AccountTransactionsQuery>,
+    State(client): State<Arc<HorizonClient>>,
+) -> Result<Json<PaginatedResponse<TransactionSummary>>, AppError> {
+    let limit = params.limit.unwrap_or(10);
+    let order = params.order.as_deref().unwrap_or("asc");
+
+    if limit == 0 || limit > 50 {
+        return Err(AppError::BadRequest(
+            "limit must be between 1 and 50".to_string(),
+        ));
+    }
+
+    if order != "asc" && order != "desc" {
+        return Err(AppError::BadRequest(
+            "order must be 'asc' or 'desc'".to_string(),
+        ));
+    }
+
+    let (records, next_cursor, prev_cursor) = client
+        .fetch_account_transactions(&address, limit, params.cursor.as_deref(), order)
+        .await?;
+
+    let items = records
+        .into_iter()
+        .map(|tx| {
+            let memo = match tx.memo_type.as_deref() {
+                Some("none") | None => None,
+                _ => tx.memo.clone(),
+            };
+            let summary = format!(
+                "{} transaction with {} operation{}.",
+                if tx.successful { "Successful" } else { "Failed" },
+                tx.operation_count,
+                if tx.operation_count == 1 { "" } else { "s" },
+            );
+            TransactionSummary {
+                hash: tx.hash,
+                created_at: tx.created_at,
+                successful: tx.successful,
+                operation_count: tx.operation_count,
+                memo,
+                summary,
+            }
+        })
+        .collect();
+
+    Ok(Json(PaginatedResponse {
+        items,
+        next_cursor,
+        prev_cursor,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn validate(limit: Option<u32>, order: Option<&str>) -> Result<(u32, &'static str), AppError> {
+        let limit = limit.unwrap_or(10);
+        let order = order.unwrap_or("asc");
+
+        if limit == 0 || limit > 50 {
+            return Err(AppError::BadRequest(
+                "limit must be between 1 and 50".to_string(),
+            ));
+        }
+        if order != "asc" && order != "desc" {
+            return Err(AppError::BadRequest(
+                "order must be 'asc' or 'desc'".to_string(),
+            ));
+        }
+        Ok((limit, if order == "asc" { "asc" } else { "desc" }))
+    }
+
+    #[test]
+    fn test_default_pagination() {
+        let (limit, order) = validate(None, None).unwrap();
+        assert_eq!(limit, 10);
+        assert_eq!(order, "asc");
+    }
+
+    #[test]
+    fn test_custom_limit_and_order() {
+        let (limit, order) = validate(Some(25), Some("desc")).unwrap();
+        assert_eq!(limit, 25);
+        assert_eq!(order, "desc");
+    }
+
+    #[test]
+    fn test_max_limit_accepted() {
+        let (limit, _) = validate(Some(50), None).unwrap();
+        assert_eq!(limit, 50);
+    }
+
+    #[test]
+    fn test_limit_zero_rejected() {
+        assert!(matches!(validate(Some(0), None), Err(AppError::BadRequest(_))));
+    }
+
+    #[test]
+    fn test_limit_over_max_rejected() {
+        assert!(matches!(
+            validate(Some(51), None),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn test_invalid_order_rejected() {
+        assert!(matches!(
+            validate(Some(10), Some("latest")),
+            Err(AppError::BadRequest(_))
+        ));
+    }
+
+    #[test]
+    fn test_cursor_navigation_values_are_passed_through() {
+        let cursor: Option<String> = Some("157639564177408001".to_string());
+        assert_eq!(cursor.as_deref(), Some("157639564177408001"));
+    }
+}

--- a/packages/core/src/routes/mod.rs
+++ b/packages/core/src/routes/mod.rs
@@ -3,3 +3,4 @@
 //! Route handlers and routers will be defined here.
 //! Intentionally empty for initial scaffolding.
 pub mod tx;
+pub mod account;

--- a/packages/core/src/services/horizon_test.rs
+++ b/packages/core/src/services/horizon_test.rs
@@ -58,4 +58,121 @@ mod tests {
 
         matches!(err, crate::errors::HorizonError::InvalidResponse);
     }
+
+    #[tokio::test]
+    async fn fetch_account_transactions_default_pagination() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/accounts/GABC/transactions")
+                .query_param("limit", "10")
+                .query_param("order", "asc");
+            then.status(200).json_body(serde_json::json!({
+                "_links": {
+                    "next": { "href": format!("{}/accounts/GABC/transactions?cursor=TOKEN_NEXT&limit=10&order=asc", base) },
+                    "prev": { "href": format!("{}/accounts/GABC/transactions?cursor=TOKEN_PREV&limit=10&order=asc", base) }
+                },
+                "_embedded": {
+                    "records": [
+                        {
+                            "hash": "tx1",
+                            "successful": true,
+                            "created_at": "2024-01-01T00:00:00Z",
+                            "source_account": "GABC",
+                            "operation_count": 1,
+                            "memo_type": "none"
+                        }
+                    ]
+                }
+            }));
+        });
+
+        let client = HorizonClient::new(server.base_url());
+        let (records, next, prev) = client
+            .fetch_account_transactions("GABC", 10, None, "asc")
+            .await
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].hash, "tx1");
+        assert_eq!(next.as_deref(), Some("TOKEN_NEXT"));
+        assert_eq!(prev.as_deref(), Some("TOKEN_PREV"));
+    }
+
+    #[tokio::test]
+    async fn fetch_account_transactions_custom_limit() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/accounts/GXYZ/transactions")
+                .query_param("limit", "25")
+                .query_param("order", "desc");
+            then.status(200).json_body(serde_json::json!({
+                "_links": {
+                    "next": { "href": format!("{}/accounts/GXYZ/transactions?cursor=C2&limit=25&order=desc", base) },
+                    "prev": { "href": format!("{}/accounts/GXYZ/transactions?cursor=C1&limit=25&order=desc", base) }
+                },
+                "_embedded": { "records": [] }
+            }));
+        });
+
+        let client = HorizonClient::new(server.base_url());
+        let (records, next, _) = client
+            .fetch_account_transactions("GXYZ", 25, None, "desc")
+            .await
+            .unwrap();
+
+        assert!(records.is_empty());
+        assert_eq!(next.as_deref(), Some("C2"));
+    }
+
+    #[tokio::test]
+    async fn fetch_account_transactions_cursor_navigation() {
+        let server = MockServer::start();
+        let base = server.base_url();
+
+        server.mock(|when, then| {
+            when.method(GET)
+                .path("/accounts/GABC/transactions")
+                .query_param("cursor", "MY_CURSOR");
+            then.status(200).json_body(serde_json::json!({
+                "_links": {
+                    "next": { "href": format!("{}/accounts/GABC/transactions?cursor=NEXT&limit=10&order=asc", base) },
+                    "prev": { "href": format!("{}/accounts/GABC/transactions?cursor=PREV&limit=10&order=asc", base) }
+                },
+                "_embedded": { "records": [] }
+            }));
+        });
+
+        let client = HorizonClient::new(server.base_url());
+        let (_, next, prev) = client
+            .fetch_account_transactions("GABC", 10, Some("MY_CURSOR"), "asc")
+            .await
+            .unwrap();
+
+        assert_eq!(next.as_deref(), Some("NEXT"));
+        assert_eq!(prev.as_deref(), Some("PREV"));
+    }
+
+    #[tokio::test]
+    async fn fetch_account_transactions_not_found() {
+        let server = MockServer::start();
+
+        server.mock(|when, then| {
+            when.method(GET).path("/accounts/GBAD/transactions");
+            then.status(404);
+        });
+
+        let client = HorizonClient::new(server.base_url());
+        let err = client
+            .fetch_account_transactions("GBAD", 10, None, "asc")
+            .await
+            .unwrap_err();
+
+        matches!(err, crate::errors::HorizonError::AccountNotFound);
+    }
 }


### PR DESCRIPTION
Summary

  - Adds GET /account/:address endpoint returning an explainability response with XLM balance, asset count, signer count, and
  plain-English flag descriptions
  - Adds GET /account/:address/transactions with cursor-based pagination (limit, cursor, order query params) and per-transaction        
  summaries
  - Adds fetch_account() and fetch_account_transactions() methods to HorizonClient
  - Introduces AccountNotFound to HorizonError for clean error propagation
  - Adds src/models/account.rs and src/explain/account.rs with unit tests; extends horizon_test.rs with httpmock-based pagination and   
  error tests
  
closes  #99 
closes #100 