### PR TITLE
feat(core): add GET /tx/:hash/raw endpoint returning unprocessed Horizon response

### DIFF
--- a/packages/core/Cargo.lock
+++ b/packages/core/Cargo.lock
@@ -2362,6 +2362,7 @@ name = "stellar-explain-core"
 version = "0.0.1"
 dependencies = [
  "axum",
+ "bytes",
  "dotenvy",
  "governor",
  "httpmock",

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 axum = "0.7"
+bytes = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -92,6 +92,24 @@ Expected response:
 ok
 ```
 
+### GET /tx/:hash
+
+Returns a human-readable explanation of a Stellar transaction.
+
+```bash
+curl http://localhost:4000/tx/<transaction-hash>
+```
+
+### GET /tx/:hash/raw
+
+Returns the raw, unprocessed JSON response from Horizon for the given transaction hash. Useful for developers and power users who want direct access to the full Horizon data.
+
+```bash
+curl http://localhost:4000/tx/<transaction-hash>/raw
+```
+
+Applies the same error handling as `/tx/:hash` — 400 for invalid hashes, 404 for not found, 502 for upstream failures.
+
 ---
 
 ## 🧪 Testing

--- a/packages/core/src/main.rs
+++ b/packages/core/src/main.rs
@@ -121,6 +121,7 @@ async fn main() {
     let app = Router::new()
         .route("/health", get(health))
         .route("/tx/:hash", get(routes::tx::get_tx_explanation))
+        .route("/tx/:hash/raw", get(routes::tx::get_tx_raw))
 
         // OpenAPI JSON
         .route(

--- a/packages/core/src/routes/mod.rs
+++ b/packages/core/src/routes/mod.rs
@@ -4,7 +4,8 @@ use utoipa::OpenApi;
 #[openapi(
     paths(
         health::health,
-        tx::get_tx_explanation
+        tx::get_tx_explanation,
+        tx::get_tx_raw
     ),
     components(
         schemas(

--- a/packages/core/src/services/mod.rs
+++ b/packages/core/src/services/mod.rs
@@ -2,3 +2,6 @@ pub mod explain;
 pub mod horizon;
 pub mod labels;
 pub mod transaction_cache;
+
+#[cfg(test)]
+mod horizon_test;


### PR DESCRIPTION

## Summary

- Adds `GET /tx/:hash/raw` route that proxies the raw Horizon JSON body directly to the caller with `Content-Type: application/json`
- Adds `fetch_transaction_raw` to `HorizonClient` using `res.bytes()` to avoid deserialisation
- Applies identical error handling to `/tx/:hash` — 400 for invalid hash, 404 for not found, 502 for upstream failures
- Registers the route in the router and OpenAPI spec
- Documents the endpoint in the README
- Wires up `horizon_test.rs` into the module tree (was previously unreachable) and adds 3 tests covering the happy path, 404, and 5xx cases

## Test plan

- [ ] `cargo test` passes (170 tests, 0 failures)
- [ ] `GET /tx/:hash/raw` returns the full Horizon JSON body unmodified
- [ ] `GET /tx/:hash/raw` with an invalid hash returns 400
- [ ] `GET /tx/:hash/raw` with an unknown hash returns 404

Closes #85
