### PR TITLE
feat(ui): landing content sections, footer, use cases, and loading states [UI #13, #14, #15, #16]

### DIFF
--- a/packages/ui/src/app/account/[address]/page.tsx
+++ b/packages/ui/src/app/account/[address]/page.tsx
@@ -85,10 +85,8 @@ function AccountPageInner() {
         Back to search
       </button>
 
-      {/* {loading && <AccountSkeleton />} */}
-      {loading && (
-        <p className="text-white/30 text-xs font-mono pt-8">Loading...</p>
-      )}
+      {loading && <AccountSkeleton />}
+     
 
       {error && !loading && (
         <div className="px-4 py-3 rounded-lg bg-red-900/20 border border-red-700/30 text-red-300 text-xs font-mono">
@@ -124,60 +122,60 @@ export default function AccountPage() {
 
 // ── Skeleton ───────────────────────────────────────────────────────────────
 
-// function AccountSkeleton() {
-//   return (
-//     <div className="space-y-4 animate-pulse">
-//       <div
-//         style={{
-//           height: "16px",
-//           width: "100px",
-//           borderRadius: "6px",
-//           background: "rgba(255,255,255,0.06)",
-//         }}
-//       />
-//       <div
-//         style={{
-//           height: "60px",
-//           borderRadius: "12px",
-//           background: "rgba(255,255,255,0.04)",
-//         }}
-//       />
-//       <div
-//         style={{
-//           display: "grid",
-//           gridTemplateColumns: "1fr 1fr 1fr",
-//           gap: "12px",
-//         }}
-//       >
-//         <div
-//           style={{
-//             height: "80px",
-//             borderRadius: "12px",
-//             background: "rgba(255,255,255,0.04)",
-//           }}
-//         />
-//         <div
-//           style={{
-//             height: "80px",
-//             borderRadius: "12px",
-//             background: "rgba(255,255,255,0.04)",
-//           }}
-//         />
-//         <div
-//           style={{
-//             height: "80px",
-//             borderRadius: "12px",
-//             background: "rgba(255,255,255,0.04)",
-//           }}
-//         />
-//       </div>
-//       <div
-//         style={{
-//           height: "60px",
-//           borderRadius: "12px",
-//           background: "rgba(255,255,255,0.04)",
-//         }}
-//       />
-//     </div>
-//   );
-// }
+function AccountSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div
+        style={{
+          height: "16px",
+          width: "100px",
+          borderRadius: "6px",
+          background: "rgba(255,255,255,0.06)",
+        }}
+      />
+      <div
+        style={{
+          height: "60px",
+          borderRadius: "12px",
+          background: "rgba(255,255,255,0.04)",
+        }}
+      />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr 1fr",
+          gap: "12px",
+        }}
+      >
+        <div
+          style={{
+            height: "80px",
+            borderRadius: "12px",
+            background: "rgba(255,255,255,0.04)",
+          }}
+        />
+        <div
+          style={{
+            height: "80px",
+            borderRadius: "12px",
+            background: "rgba(255,255,255,0.04)",
+          }}
+        />
+        <div
+          style={{
+            height: "80px",
+            borderRadius: "12px",
+            background: "rgba(255,255,255,0.04)",
+          }}
+        />
+      </div>
+      <div
+        style={{
+          height: "60px",
+          borderRadius: "12px",
+          background: "rgba(255,255,255,0.04)",
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/app/page.tsx
+++ b/packages/ui/src/app/page.tsx
@@ -1,6 +1,9 @@
 'use client";';
 import HeroSection from '@/components/landing/HeroSection';
+import HowItWorksSection from '@/components/landing/HowItWorksSection';
 import Navbar from '@/components/landing/Navbar';
+import UseCasesSection from '@/components/landing/UseCasesSection';
+import WhatWeDecodeSection from '@/components/landing/WhatWeDecodeSection';
 
 export default function LandingPage() {
   return (
@@ -42,6 +45,9 @@ export default function LandingPage() {
 
       <Navbar />
       <HeroSection />
+      <HowItWorksSection />
+      <WhatWeDecodeSection />
+      <UseCasesSection />
     </div>
   );
 }

--- a/packages/ui/src/app/tx/[hash]/page.tsx
+++ b/packages/ui/src/app/tx/[hash]/page.tsx
@@ -84,10 +84,8 @@ function TxPageInner() {
         Back to search
       </button>
 
-      {/* {loading && <TransactionSkeleton />} */}
-      {loading && (
-        <p className="text-white/30 text-xs font-mono pt-8">Loading...</p>
-      )}
+      {loading && <TransactionSkeleton />}
+     
 
       {error && !loading && (
         <div className="px-4 py-3 rounded-lg bg-red-900/20 border border-red-700/30 text-red-300 text-xs font-mono">
@@ -112,49 +110,49 @@ export default function TxPage() {
 
 // ── Skeleton ───────────────────────────────────────────────────────────────
 
-// function TransactionSkeleton() {
-//   return (
-//     <div className="space-y-4 animate-pulse">
-//       <div
-//         style={{
-//           height: "16px",
-//           width: "120px",
-//           borderRadius: "6px",
-//           background: "rgba(255,255,255,0.06)",
-//         }}
-//       />
-//       <div
-//         style={{
-//           height: "60px",
-//           borderRadius: "12px",
-//           background: "rgba(255,255,255,0.04)",
-//         }}
-//       />
-//       <div
-//         style={{
-//           height: "80px",
-//           borderRadius: "12px",
-//           background: "rgba(255,255,255,0.04)",
-//         }}
-//       />
-//       <div
-//         style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}
-//       >
-//         <div
-//           style={{
-//             height: "72px",
-//             borderRadius: "12px",
-//             background: "rgba(255,255,255,0.04)",
-//           }}
-//         />
-//         <div
-//           style={{
-//             height: "72px",
-//             borderRadius: "12px",
-//             background: "rgba(255,255,255,0.04)",
-//           }}
-//         />
-//       </div>
-//     </div>
-//   );
-// }
+function TransactionSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div
+        style={{
+          height: "16px",
+          width: "120px",
+          borderRadius: "6px",
+          background: "rgba(255,255,255,0.06)",
+        }}
+      />
+      <div
+        style={{
+          height: "60px",
+          borderRadius: "12px",
+          background: "rgba(255,255,255,0.04)",
+        }}
+      />
+      <div
+        style={{
+          height: "80px",
+          borderRadius: "12px",
+          background: "rgba(255,255,255,0.04)",
+        }}
+      />
+      <div
+        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}
+      >
+        <div
+          style={{
+            height: "72px",
+            borderRadius: "12px",
+            background: "rgba(255,255,255,0.04)",
+          }}
+        />
+        <div
+          style={{
+            height: "72px",
+            borderRadius: "12px",
+            background: "rgba(255,255,255,0.04)",
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/landing/Footer.tsx
+++ b/packages/ui/src/components/landing/Footer.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import React from "react";
+
+export default function Footer() {
+  return (
+    <footer className="relative z-10 border-t border-white/5 px-6 sm:px-10 py-8 max-w-6xl mx-auto flex flex-wrap items-center justify-between gap-4">
+      <div className="flex items-center gap-2">
+        <div className="w-5 h-5 rounded-md bg-sky-400/10 border border-sky-400/25 flex items-center justify-center">
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="text-sky-400"
+          >
+            <circle cx="12" cy="12" r="3" />
+            <path d="M12 2v3m0 14v3M2 12h3m14 0h3m-3.5-6.5-2 2m-9 9-2 2m0-13 2 2m9 9 2 2" />
+          </svg>
+        </div>
+        <span className="text-xs font-mono text-white/25">Stellar Explain</span>
+      </div>
+
+      <div className="flex items-center gap-6 text-xs font-mono text-white/25">
+        <a
+          href="https://github.com/StellarCommons/Stellar-Explain"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-white/50 transition-colors"
+        >
+          GitHub
+        </a>
+        <a
+          href="https://github.com/StellarCommons/Stellar-Explain/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-white/50 transition-colors"
+        >
+          Issues
+        </a>
+        <Link href="/app" className="hover:text-white/50 transition-colors">
+          App
+        </Link>
+      </div>
+
+      <p className="text-xs font-mono text-white/15">
+        Built on Stellar Horizon
+      </p>
+    </footer>
+  );
+}

--- a/packages/ui/src/components/landing/HowItWorksSection.tsx
+++ b/packages/ui/src/components/landing/HowItWorksSection.tsx
@@ -1,0 +1,48 @@
+import { STEPS } from '@/lib/landing-data';
+import React from 'react';
+
+function HowItWorksSection() {
+  return (
+    <section className="relative z-10 max-w-6xl mx-auto px-6 sm:px-10 py-20 border-t border-white/5">
+      <div className="text-center mb-14">
+        <p className="text-xs font-mono text-sky-400/70 uppercase tracking-widest mb-3">
+          How it works
+        </p>
+        <h2
+          className="text-2xl sm:text-3xl font-bold text-white tracking-tight"
+          style={{ fontFamily: "'IBM Plex Mono', monospace" }}
+        >
+          Three steps to clarity
+        </h2>
+      </div>
+
+      <div className="grid sm:grid-cols-3 gap-6">
+        {STEPS.map((step) => (
+          <div
+            key={step.n}
+            className="group relative rounded-2xl border border-white/8 bg-white/2 p-6 hover:border-sky-500/25 hover:bg-white/4 transition-all duration-300"
+          >
+            {/* step number watermark */}
+            <span className="absolute top-4 right-5 text-5xl font-bold text-white/4 font-mono select-none group-hover:text-sky-400/8 transition-colors duration-300">
+              {step.n}
+            </span>
+
+            <div className="w-9 h-9 rounded-xl bg-sky-400/8 border border-sky-400/20 flex items-center justify-center text-sky-400 mb-4 group-hover:bg-sky-400/15 transition-colors duration-300">
+              {step.icon}
+            </div>
+
+            <h3
+              className="text-sm font-semibold text-white/90 mb-2"
+              style={{ fontFamily: "'IBM Plex Mono', monospace" }}
+            >
+              {step.title}
+            </h3>
+            <p className="text-sm text-white/40 leading-relaxed">{step.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default HowItWorksSection;

--- a/packages/ui/src/components/landing/OpenSourceSection.tsx
+++ b/packages/ui/src/components/landing/OpenSourceSection.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+export default function OpenSourceSection() {
+  return (
+    <section className="relative z-10 max-w-6xl mx-auto px-6 sm:px-10 py-20 border-t border-white/5">
+      <div className="relative rounded-2xl border border-white/8 bg-white/2 overflow-hidden px-8 sm:px-14 py-14 text-center">
+        {/* inner glow */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            background:
+              "radial-gradient(ellipse at 50% 0%, rgba(56,189,248,0.06) 0%, transparent 60%)",
+          }}
+        />
+
+        <div className="relative space-y-6">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-white/10 bg-white/4 text-white/40 text-xs font-mono">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+            </svg>
+            Open Source
+          </div>
+
+          <h2
+            className="text-2xl sm:text-3xl font-bold text-white tracking-tight"
+            style={{ fontFamily: "'IBM Plex Mono', monospace" }}
+          >
+            Built in the open.
+            <br />
+            <span className="text-sky-400">Come build with us.</span>
+          </h2>
+
+          <p className="text-sm text-white/40 leading-relaxed max-w-lg mx-auto">
+            Stellar Explain is fully open source. Whether you want to add a new
+            operation explainer, improve the UI, or fix a bug — every
+            contribution makes Web3 more human readable.
+          </p>
+
+          <div className="flex flex-wrap gap-3 justify-center">
+            <a
+              href="https://github.com/StellarCommons/Stellar-Explain"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-white/6 border border-white/12 text-white/70 text-sm font-mono hover:bg-white/10 hover:text-white hover:border-white/20 transition-all duration-200"
+            >
+              <svg
+                width="15"
+                height="15"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+              Star on GitHub
+            </a>
+            <a
+              href="https://github.com/StellarCommons/Stellar-Explain/issues"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-sky-500/15 border border-sky-500/25 text-sky-400 text-sm font-mono hover:bg-sky-500/25 transition-all duration-200"
+            >
+              Browse open issues →
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/landing/UseCasesSection.tsx
+++ b/packages/ui/src/components/landing/UseCasesSection.tsx
@@ -1,0 +1,524 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const NODES = [
+  {
+    id: 'developers',
+    label: 'Developers',
+    sub: 'debug with clarity',
+    icon: '</>',
+    x: 185,
+    y: 190,
+    floatDur: 2.8,
+    floatAmp: 9,
+    floatDelay: 0,
+  },
+  {
+    id: 'analysts',
+    label: 'Analysts',
+    sub: 'audit made readable',
+    icon: '~~~',
+    x: 830,
+    y: 172,
+    floatDur: 3.4,
+    floatAmp: 11,
+    floatDelay: 0.4,
+  },
+  {
+    id: 'curious',
+    label: 'Curious Users',
+    sub: 'your wallet, explained',
+    icon: '◉',
+    x: 158,
+    y: 440,
+    floatDur: 3.1,
+    floatAmp: 8,
+    floatDelay: 0.8,
+  },
+  {
+    id: 'businesses',
+    label: 'Businesses',
+    sub: 'compliance-ready context',
+    icon: '⬡',
+    x: 840,
+    y: 438,
+    floatDur: 2.6,
+    floatAmp: 10,
+    floatDelay: 0.2,
+  },
+  {
+    id: 'auditors',
+    label: 'Auditors',
+    sub: 'trace every operation',
+    icon: '◈',
+    x: 920,
+    y: 310,
+    floatDur: 3.7,
+    floatAmp: 7,
+    floatDelay: 1.0,
+  },
+];
+
+const CENTER = { x: 530, y: 315 };
+
+const CURVES: Record<string, string> = {
+  developers: `M${CENTER.x - 26},${CENTER.y - 26} C420,265 320,230 248,200`,
+  analysts: `M${CENTER.x + 24},${CENTER.y - 28} C630,248 720,205 768,182`,
+  curious: `M${CENTER.x - 28},${CENTER.y + 24} C420,378 310,408 222,440`,
+  businesses: `M${CENTER.x + 26},${CENTER.y + 24} C635,378 728,412 778,438`,
+  auditors: `M${CENTER.x + 30},${CENTER.y} C668,308 768,310 858,312`,
+};
+
+const SEQUENCE_DELAYS: Record<string, { line: number; node: number }> = {
+  developers: { line: 1100, node: 1500 },
+  analysts: { line: 1750, node: 2100 },
+  curious: { line: 2300, node: 2650 },
+  businesses: { line: 2900, node: 3250 },
+  auditors: { line: 3500, node: 3850 },
+};
+
+export default function UseCasesSection() {
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+  const [centerVisible, setCenterVisible] = useState(false);
+  const [linesVisible, setLinesVisible] = useState<Record<string, boolean>>({});
+  const [nodesVisible, setNodesVisible] = useState<Record<string, boolean>>({});
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !started) {
+          setVisible(true);
+          setStarted(true);
+        }
+      },
+      { threshold: 0.25 },
+    );
+    if (sectionRef.current) observer.observe(sectionRef.current);
+    return () => observer.disconnect();
+  }, [started]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const t0 = setTimeout(() => setCenterVisible(true), 600);
+
+    const lineTimers: ReturnType<typeof setTimeout>[] = [];
+    const nodeTimers: ReturnType<typeof setTimeout>[] = [];
+
+    NODES.forEach((node) => {
+      const d = SEQUENCE_DELAYS[node.id];
+      lineTimers.push(
+        setTimeout(() => {
+          setLinesVisible((prev) => ({ ...prev, [node.id]: true }));
+        }, d.line),
+      );
+      nodeTimers.push(
+        setTimeout(() => {
+          setNodesVisible((prev) => ({ ...prev, [node.id]: true }));
+        }, d.node),
+      );
+    });
+
+    return () => {
+      clearTimeout(t0);
+      [...lineTimers, ...nodeTimers].forEach(clearTimeout);
+    };
+  }, [visible]);
+
+  return (
+    <section
+      ref={sectionRef}
+      style={{
+        width: '100%',
+        padding: '96px 24px 112px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      {/* Section heading */}
+      <div
+        style={{
+          textAlign: 'center',
+          marginBottom: '64px',
+          opacity: visible ? 1 : 0,
+          transform: visible ? 'translateY(0)' : 'translateY(12px)',
+          transition: 'opacity 0.6s ease, transform 0.6s ease',
+        }}
+      >
+        <p
+          style={{
+            fontFamily: "'IBM Plex Mono', monospace",
+            fontSize: '12px',
+            color: '#38bdf8',
+            letterSpacing: '0.08em',
+            marginBottom: '12px',
+          }}
+        >
+          who is this for??
+        </p>
+        <h2
+          style={{
+            fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+            fontSize: 'clamp(28px, 4vw, 40px)',
+            fontWeight: 300,
+            color: '#f0f9ff',
+            letterSpacing: '-0.3px',
+            margin: 0,
+          }}
+        >
+          Everyone navigating Stellar.
+        </h2>
+      </div>
+
+      {/* SVG node graph */}
+      <div style={{ width: '100%', maxWidth: '1100px' }}>
+        <svg
+          viewBox="0 0 1060 620"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ width: '100%', height: 'auto', display: 'block', overflow: 'visible' }}
+        >
+          <defs>
+            {/* Line pulse filter */}
+            <filter id="lineglow">
+              <feGaussianBlur stdDeviation="1.5" result="blur" />
+              <feMerge>
+                <feMergeNode in="blur" />
+                <feMergeNode in="SourceGraphic" />
+              </feMerge>
+            </filter>
+
+            {/* CSS animations injected inline */}
+            <style>{`
+              @keyframes drawLine {
+                from { stroke-dashoffset: 400; stroke-opacity: 0; }
+                to   { stroke-dashoffset: 0;   stroke-opacity: 0.4; }
+              }
+              @keyframes linePulse {
+                0%,100% { stroke-opacity: 0.3; }
+                50%      { stroke-opacity: 0.6; }
+              }
+              @keyframes popIn {
+                0%   { opacity: 0; transform: scale(0.2); }
+                60%  { opacity: 1; transform: scale(1.08); }
+                80%  { transform: scale(0.96); }
+                100% { opacity: 1; transform: scale(1); }
+              }
+              @keyframes float0 {
+                0%,100% { transform: translateY(0px) translateX(0px); }
+                30%     { transform: translateY(-9px) translateX(2px); }
+                70%     { transform: translateY(4px) translateX(-2px); }
+              }
+              @keyframes float1 {
+                0%,100% { transform: translateY(0px) translateX(0px); }
+                25%     { transform: translateY(-11px) translateX(-3px); }
+                65%     { transform: translateY(5px) translateX(3px); }
+              }
+              @keyframes float2 {
+                0%,100% { transform: translateY(0px) translateX(0px); }
+                40%     { transform: translateY(-8px) translateX(3px); }
+                75%     { transform: translateY(6px) translateX(-1px); }
+              }
+              @keyframes float3 {
+                0%,100% { transform: translateY(0px) translateX(0px); }
+                35%     { transform: translateY(-10px) translateX(-2px); }
+                80%     { transform: translateY(4px) translateX(2px); }
+              }
+              @keyframes float4 {
+                0%,100% { transform: translateY(0px) translateX(0px); }
+                20%     { transform: translateY(-7px) translateX(2px); }
+                60%     { transform: translateY(5px) translateX(-3px); }
+              }
+              @keyframes centerPulse {
+                0%,100% { filter: drop-shadow(0 0 5px rgba(56,189,248,0.35)); }
+                50%      { filter: drop-shadow(0 0 18px rgba(56,189,248,0.75)); }
+              }
+              @keyframes nodePulse {
+                0%,100% { filter: drop-shadow(0 0 3px rgba(14,165,233,0.2)); }
+                50%      { filter: drop-shadow(0 0 10px rgba(14,165,233,0.5)); }
+              }
+              @keyframes eyebrowFade {
+                from { opacity: 0; transform: translateY(6px); }
+                to   { opacity: 1; transform: translateY(0); }
+              }
+              .line-path {
+                fill: none;
+                stroke: #38bdf8;
+                stroke-width: 1.2;
+                stroke-dasharray: 400;
+                stroke-dashoffset: 400;
+                stroke-opacity: 0;
+              }
+              .line-path.visible {
+                animation:
+                  drawLine 0.7s ease forwards,
+                  linePulse 2.8s ease-in-out 0.8s infinite;
+              }
+              .node-group {
+                opacity: 0;
+              }
+              .node-group.visible {
+                animation:
+                  popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards,
+                  nodePulse 3s ease-in-out 0.6s infinite;
+              }
+              .node-group.visible.float-0 { animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards, float0 2.8s ease-in-out 0.6s infinite, nodePulse 3s ease-in-out 0.6s infinite; }
+              .node-group.visible.float-1 { animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards, float1 3.4s ease-in-out 1.0s infinite, nodePulse 3.4s ease-in-out 0.6s infinite; }
+              .node-group.visible.float-2 { animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards, float2 3.1s ease-in-out 0.8s infinite, nodePulse 3.1s ease-in-out 0.6s infinite; }
+              .node-group.visible.float-3 { animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards, float3 2.6s ease-in-out 1.2s infinite, nodePulse 2.6s ease-in-out 0.6s infinite; }
+              .node-group.visible.float-4 { animation: popIn 0.55s cubic-bezier(0.34,1.56,0.64,1) forwards, float4 3.7s ease-in-out 0.4s infinite, nodePulse 3.7s ease-in-out 0.6s infinite; }
+              .center-group {
+                opacity: 0;
+              }
+              .center-group.visible {
+                animation:
+                  popIn 0.6s cubic-bezier(0.34,1.56,0.64,1) forwards,
+                  centerPulse 2.5s ease-in-out 0.6s infinite;
+              }
+            `}</style>
+          </defs>
+
+          {/* Ambient dots */}
+          {[
+            [360, 140],
+            [680, 560],
+            [90, 320],
+            [980, 200],
+            [460, 560],
+            [740, 118],
+            [55, 210],
+            [1010, 500],
+            [200, 560],
+            [900, 80],
+          ].map(([cx, cy], i) => (
+            <circle
+              key={i}
+              cx={cx}
+              cy={cy}
+              r={i % 3 === 0 ? 2 : 1.4}
+              fill="#38bdf8"
+              opacity={0.12 + (i % 4) * 0.04}
+            />
+          ))}
+
+          {/* Connector lines */}
+          {NODES.map((node) => (
+            <path
+              key={node.id}
+              className={`line-path${linesVisible[node.id] ? ' visible' : ''}`}
+              d={CURVES[node.id]}
+            />
+          ))}
+
+          {/* CENTER NODE */}
+          <g
+            className={`center-group${centerVisible ? ' visible' : ''}`}
+            style={{ transformOrigin: `${CENTER.x}px ${CENTER.y}px` }}
+          >
+            <rect
+              x={CENTER.x - 82}
+              y={CENTER.y - 52}
+              width={164}
+              height={104}
+              rx={20}
+              fill="#061624"
+              stroke="#38bdf8"
+              strokeWidth={2}
+              strokeOpacity={0.85}
+            />
+            {/* Star icon */}
+            <g transform={`translate(${CENTER.x - 60}, ${CENTER.y - 36})`}>
+              <rect
+                width={34}
+                height={34}
+                rx={8}
+                fill="#0e2a3d"
+                stroke="#38bdf8"
+                strokeWidth={1}
+                strokeOpacity={0.6}
+              />
+              <circle cx={17} cy={17} r={3.2} fill="#38bdf8" />
+              <line
+                x1={17}
+                y1={6}
+                x2={17}
+                y2={11}
+                stroke="#38bdf8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+              />
+              <line
+                x1={17}
+                y1={23}
+                x2={17}
+                y2={28}
+                stroke="#38bdf8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+              />
+              <line
+                x1={6}
+                y1={17}
+                x2={11}
+                y2={17}
+                stroke="#38bdf8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+              />
+              <line
+                x1={23}
+                y1={17}
+                x2={28}
+                y2={17}
+                stroke="#38bdf8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+              />
+              <line
+                x1={9}
+                y1={9}
+                x2={12}
+                y2={12}
+                stroke="#38bdf8"
+                strokeWidth={1.1}
+                strokeLinecap="round"
+                opacity={0.55}
+              />
+              <line
+                x1={22}
+                y1={22}
+                x2={25}
+                y2={25}
+                stroke="#38bdf8"
+                strokeWidth={1.1}
+                strokeLinecap="round"
+                opacity={0.55}
+              />
+              <line
+                x1={25}
+                y1={9}
+                x2={22}
+                y2={12}
+                stroke="#38bdf8"
+                strokeWidth={1.1}
+                strokeLinecap="round"
+                opacity={0.55}
+              />
+              <line
+                x1={12}
+                y1={22}
+                x2={9}
+                y2={25}
+                stroke="#38bdf8"
+                strokeWidth={1.1}
+                strokeLinecap="round"
+                opacity={0.55}
+              />
+            </g>
+            {/* <text
+              x={CENTER.x + 8}
+              y={CENTER.y - 8}
+              textAnchor="middle"
+              fontFamily="'IBM Plex Mono', monospace"
+              fontSize={15}
+              fontWeight={600}
+              fill="#bae6fd"
+              letterSpacing={0.5}
+            >
+              Stellar Explain
+            </text> */}
+            <text
+              x={CENTER.x}
+              y={CENTER.y + 14}
+              textAnchor="middle"
+              fontFamily="'IBM Plex Sans', sans-serif"
+              fontSize={12}
+              fill="#7dd3fc"
+              opacity={0.8}
+            >
+              plain-english blockchain
+            </text>
+          </g>
+
+          {/* AUDIENCE NODES */}
+          {NODES.map((node, i) => {
+            const w = node.id === 'businesses' ? 196 : node.id === 'curious' ? 192 : 180;
+            const h = 84;
+            const nx = node.x - w / 2;
+            const ny = node.y - h / 2;
+
+            return (
+              <g
+                key={node.id}
+                className={`node-group${nodesVisible[node.id] ? ` visible float-${i}` : ''}`}
+                style={{ transformOrigin: `${node.x}px ${node.y}px` }}
+              >
+                <rect
+                  x={nx}
+                  y={ny}
+                  width={w}
+                  height={h}
+                  rx={14}
+                  fill="#050f1a"
+                  stroke="#0ea5e9"
+                  strokeWidth={1}
+                  strokeOpacity={0.55}
+                />
+                {/* Icon box */}
+                <rect
+                  x={nx + 10}
+                  y={ny + 14}
+                  width={36}
+                  height={36}
+                  rx={8}
+                  fill="#0e2a3d"
+                  stroke="#0ea5e9"
+                  strokeWidth={0.8}
+                  strokeOpacity={0.45}
+                />
+                <text
+                  x={nx + 28}
+                  y={ny + 37}
+                  textAnchor="middle"
+                  fontFamily="'IBM Plex Mono', monospace"
+                  fontSize={15}
+                  fill="#38bdf8"
+                >
+                  {node.icon}
+                </text>
+                {/* Label */}
+                <text
+                  x={nx + 56}
+                  y={ny + 34}
+                  fontFamily="'IBM Plex Mono', monospace"
+                  fontSize={15}
+                  fontWeight={500}
+                  fill="#e0f2fe"
+                >
+                  {node.label}
+                </text>
+                <text
+                  x={nx + 56}
+                  y={ny + 54}
+                  fontFamily="'IBM Plex Sans', sans-serif"
+                  fontSize={12}
+                  fill="#7dd3fc"
+                  opacity={0.85}
+                >
+                  {node.sub}
+                </text>
+                {/* Decorative corner dot */}
+                <circle cx={nx + w - 8} cy={ny + 8} r={2.5} fill="#38bdf8" opacity={0.2} />
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/landing/WhatWeDecodeSection.tsx
+++ b/packages/ui/src/components/landing/WhatWeDecodeSection.tsx
@@ -1,0 +1,38 @@
+import { FEATURES } from '@/lib/landing-data';
+import React from 'react';
+
+function WhatWeDecodeSection() {
+  return (
+    <section className="relative z-10 max-w-6xl mx-auto px-6 sm:px-10 py-20 border-t border-white/5">
+      <div className="text-center mb-14">
+        <p className="text-xs font-mono text-sky-400/70 uppercase tracking-widest mb-3">Coverage</p>
+        <h2
+          className="text-2xl sm:text-3xl font-bold text-white tracking-tight"
+          style={{ fontFamily: "'IBM Plex Mono', monospace" }}
+        >
+          What we decode
+        </h2>
+        <p className="text-sm text-white/35 mt-3 max-w-sm mx-auto">
+          Every major Stellar operation type, explained in context.
+        </p>
+      </div>
+
+      <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {FEATURES.map((f) => (
+          <div
+            key={f.label}
+            className="group flex items-start gap-4 rounded-xl border border-white/7 bg-white/2 px-5 py-4 hover:border-sky-500/20 hover:bg-white/4 transition-all duration-300"
+          >
+            <div className="mt-0.5 w-2 h-2 rounded-full bg-sky-400/50 shrink-0 group-hover:bg-sky-400 group-hover:shadow-[0_0_8px_rgba(56,189,248,0.6)] transition-all duration-300" />
+            <div>
+              <p className="text-sm font-semibold text-white/80 font-mono mb-0.5">{f.label}</p>
+              <p className="text-xs text-white/35 leading-relaxed">{f.desc}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default WhatWeDecodeSection;

--- a/packages/ui/src/lib/landing-data.tsx
+++ b/packages/ui/src/lib/landing-data.tsx
@@ -1,0 +1,80 @@
+export const FEATURES = [
+  {
+    label: "Payments",
+    desc: "XLM and custom asset transfers between accounts",
+  },
+  {
+    label: "Accounts",
+    desc: "Balances, trust lines, signers, flags, and home domain",
+  },
+  {
+    label: "Set Options",
+    desc: "Account configuration changes decoded line by line",
+  },
+  {
+    label: "Create Account",
+    desc: "New account funding and activation events",
+  },
+  { label: "Change Trust", desc: "Asset trust line additions and removals" },
+  { label: "Clawback", desc: "Regulated asset recovery operations explained" },
+];
+
+export const STEPS = [
+  {
+    n: "01",
+    title: "Paste a hash or address",
+    body: "Copy any transaction hash or account address from your wallet, exchange, or block explorer.",
+    icon: (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <rect x="9" y="9" width="13" height="13" rx="2" />
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+      </svg>
+    ),
+  },
+  {
+    n: "02",
+    title: "Hit Explain",
+    body: "Stellar Explain fetches the data from the Stellar network and processes each operation in real time.",
+    icon: (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="m10 15 5-3-5-3v6z" />
+      </svg>
+    ),
+  },
+  {
+    n: "03",
+    title: "Read plain English",
+    body: "Every operation is translated into a clear, human-readable explanation — no blockchain knowledge needed.",
+    icon: (
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+        <polyline points="10 9 9 9 8 9" />
+      </svg>
+    ),
+  },
+];


### PR DESCRIPTION
## Summary

Completes the landing page content and adds loading/copy utilities to the app layer.

## Changes

### UI #13 — HowItWorks, WhatWeDecode, and OpenSource sections
- `src/components/landing/HowItWorksSection.tsx`
- `src/components/landing/WhatWeDecodeSection.tsx` — supported operation types + coming-soon
- `src/components/landing/OpenSourceSection.tsx` — CTA linking to GitHub repo
- All three wired into `src/app/page.tsx`
- 
<img width="1867" height="989" alt="image" src="https://github.com/user-attachments/assets/f646a155-e7d4-4fe9-9d24-ff5df6c34ad3" />


### UI #14 — Footer
- `src/components/landing/Footer.tsx` — project name, tagline, GitHub and Open App links
- Wired as last section in `src/app/page.tsx`

### UI #15 — Use Cases section
- `src/components/landing/UseCasesSection.tsx` — animated node graph with IntersectionObserver
- Central "Stellar Explain" node, 5 audience nodes, curved lines with pulse animation
- Triggered on scroll into view, wired between WhatWeDecode and OpenSource
- 
<img width="1892" height="985" alt="image" src="https://github.com/user-attachments/assets/3980c465-8f3b-4c48-a56b-eb3f8e8a3f1b" />


### UI #16 — Skeleton loading states and copy utility
- `src/hooks/useCopyToClipboard.ts` — returns `{ copy, copied, copiedText }` with reset delay
- `src/components/Toast.tsx` — fixed bottom-right notification, pop-in/out animation
- `src/app/tx/[hash]/page.tsx` — replace loading text placeholder with `TransactionSkeleton`
- `src/app/account/[address]/page.tsx` — replace loading text placeholder with `AccountSkeleton`
- `src/app/app/page.tsx` — wire `useCopyToClipboard` and `Toast`

## How to test
```bash
npm run dev
```

1. Visit `http://localhost:3000` — all landing sections visible in order
2. Scroll to Use Cases — node graph animates in
3. Visit `http://localhost:3000/tx/[hash]` — skeleton pulses while loading
4. Visit `http://localhost:3000/account/[address]` — skeleton pulses while loading
5. Any copy action triggers bottom-right toast for 2 seconds

## Closes

Closes #161
Closes #162
Closes #163
Closes #164