### PR TITLE
feat(ui): error display, network banner, env validation, and frontend  README [UI #17, #18, #19, #20]

### DIFF
--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,255 +1,205 @@
-# Stellar Explain – Core API
+# Stellar Explain — Frontend
 
-The `core` package contains the Rust backend API for Stellar Explain.
-
-It exposes HTTP endpoints that fetch data from Horizon and return structured explanations of Stellar transactions.
+The Next.js frontend for [Stellar Explain](https://github.com/StellarCommons/Stellar-Explain) — a tool that explains Stellar blockchain transactions and accounts in plain English.
 
 ---
 
-## 🚀 Getting Started
+## Prerequisites
 
-### Prerequisites
+- **Node.js** v18 or later
+- **npm** v9 or later
+- A running instance of the [Stellar Explain backend](../core/README.md) (Rust)
 
-- Rust (latest stable recommended)  
-  Install via: https://rustup.rs
-- Cargo (installed with Rust)
-- Access to a Horizon instance (defaults to public/testnet)
-- Optional: Docker (if running via container)
-
-Check your Rust version:
-
+Check your versions:
 ```bash
-rustc --version
+node --version
+npm --version
 ```
 
 ---
 
-## ⚙️ Environment Variables
-
-The API reads configuration from environment variables:
-
-| Variable          | Description                 | Default                 |
-| ----------------- | --------------------------- | ----------------------- |
-| `STELLAR_NETWORK` | `public` or `testnet`       | `public`                |
-| `HORIZON_URL`     | Custom Horizon URL override | Network default         |
-| `CORS_ORIGIN`     | Allowed CORS origin         | `http://localhost:3000` |
-| `RUST_LOG`        | Logging level               | `info`                  |
-
-Example:
+## Setup
 
 ```bash
-export STELLAR_NETWORK=testnet
-export RUST_LOG=info
+# 1. Clone the repo (if you haven't already)
+git clone https://github.com/StellarCommons/Stellar-Explain.git
+cd Stellar-Explain/packages/ui
+
+# 2. Install dependencies
+npm install
+
+# 3. Configure environment variables
+cp .env.local.example .env.local
+# Edit .env.local and set API_URL to your running backend
+
+# 4. Start the dev server
+npm run dev
 ```
+
+The app will be available at `http://localhost:3000`.
 
 ---
 
-## 🛠 Build & Run
+## Environment Variables
 
-From the repository root:
+| Variable | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `API_URL` | ✅ Yes | URL of the Stellar Explain Rust backend | `http://localhost:4000` |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | No | Network label shown in the UI | `testnet` |
 
-```bash
-cargo build --release -p core
-```
-
-Run locally:
-
-```bash
-cargo run -p core
-```
-
-The server starts on:
-
-```
-http://localhost:4000
-```
+> **Note:** `API_URL` is read server-side only and is never exposed to the browser. All requests to the backend are proxied through Next.js API routes.
 
 ---
 
-## 🧪 Running Tests
+## Scripts
 
-Run all tests:
-
-```bash
-cargo test -p core
-```
-
-Run with logs:
-
-```bash
-RUST_LOG=debug cargo test -p core
-```
+| Command | Description |
+|---------|-------------|
+| `npm run dev` | Start development server with Turbopack |
+| `npm run build` | Build for production |
+| `npm run start` | Start production server |
+| `npm run lint` | Run ESLint + TypeScript type check |
+| `npm run format` | Format all source files with Prettier |
+| `npm run format:check` | Check formatting without writing changes |
 
 ---
 
-## 🐳 Running with Docker
-
-From the project root:
-
-```bash
-docker-compose up --build
-```
-
-The API will be available at:
+## Project Structure
 
 ```
-http://localhost:4000
-```
-
-Health check:
-
-```bash
-curl http://localhost:4000/health
-```
-
----
-
-## 📡 API Endpoints
-
----
-
-### GET `/health`
-
-Returns service status and Horizon connectivity.
-
-#### Example
-
-```bash
-curl http://localhost:4000/health
-```
-
-#### Response
-
-```json
-{
-  "status": "ok",
-  "network": "testnet",
-  "horizon_reachable": true,
-  "version": "0.1.0"
-}
-```
-
-If Horizon is unreachable:
-
-- HTTP 503
-- `"status": "degraded"`
-
----
-
-### GET `/tx/:hash`
-
-Returns a structured explanation of a Stellar transaction.
-
-#### Example
-
-```bash
-curl http://localhost:4000/tx/3b7e9b6f...
-```
-
-#### Example Response
-
-```json
-{
-  "hash": "3b7e9b6f...",
-  "successful": true,
-  "fee_charged": 100,
-  "memo": "Payment for services",
-  "operations": [
-    {
-      "type": "payment",
-      "from": "GABC...",
-      "to": "GXYZ...",
-      "asset": "XLM",
-      "amount": "100.0000000"
-    }
-  ],
-  "explanation": "This transaction transferred 100 XLM from GABC... to GXYZ..."
-}
-```
-
----
-
-### GET `/account/:address` (Planned)
-
-Will return paginated transactions for an account.
-
-#### Example
-
-```bash
-curl http://localhost:4000/account/GABC...
-```
-
-#### Expected Response Structure
-
-```json
-{
-  "account": "GABC...",
-  "transactions": [],
-  "next_cursor": "...",
-  "prev_cursor": "..."
-}
-```
-
----
-
-## 🔐 Rate Limiting
-
-The API applies global per-IP rate limiting:
-
-- 60 requests per minute
-- Returns HTTP 429 if exceeded
-- Includes `Retry-After` header
-
----
-
-## 🏗 Project Structure
-
-```
-packages/core
+packages/ui/
 ├── src/
-│   ├── routes/
-│   ├── services/
-│   ├── models/
-│   ├── config/
-│   └── main.rs
-├── Cargo.toml
-└── README.md
+│   ├── app/                        # Next.js App Router pages
+│   │   ├── page.tsx                # Landing page (/)
+│   │   ├── app/page.tsx            # Search page (/app)
+│   │   ├── tx/[hash]/page.tsx      # Transaction result (/tx/:hash)
+│   │   ├── account/[address]/      # Account result (/account/:address)
+│   │   └── api/                    # Next.js proxy routes (server-side only)
+│   │       ├── tx/[hash]/route.ts
+│   │       ├── account/[address]/route.ts
+│   │       └── health/route.ts
+│   │
+│   ├── components/                 # Shared UI components
+│   │   ├── AppShell.tsx            # Shared page wrapper with header and context
+│   │   ├── AppShellContext.ts      # React context + useAppShell() hook
+│   │   ├── TransactionResult.tsx   # Transaction explanation display
+│   │   ├── AccountResult.tsx       # Account explanation display
+│   │   ├── ErrorDisplay.tsx        # Typed API error display
+│   │   ├── Toast.tsx               # Copy-to-clipboard notification
+│   │   ├── Card.tsx                # Base card wrapper
+│   │   ├── Pill.tsx                # Status pill (success/fail/warning)
+│   │   ├── Label.tsx               # Section label
+│   │   ├── AddressChip.tsx         # Truncated address with copy
+│   │   ├── TabSwitcher.tsx         # Transaction / Account tab toggle
+│   │   ├── SearchBar.tsx           # Search input + submit
+│   │   ├── landing/                # Landing page sections
+│   │   ├── history/                # Search history panel (UI #21)
+│   │   └── addressbook/            # Address book panel (UI #22)
+│   │
+│   ├── hooks/                      # Custom React hooks
+│   │   ├── useSearchHistory.ts     # localStorage search history
+│   │   ├── useAddressBook.ts       # localStorage address book
+│   │   ├── useCopyToClipboard.ts   # Clipboard with reset state
+│   │   └── usePersonalMode.ts      # Personalised explanation mode
+│   │
+│   ├── lib/                        # Utilities and API client
+│   │   ├── api.ts                  # Typed fetch functions
+│   │   ├── errors.ts               # Error type guards and helpers
+│   │   └── utils.ts                # Formatting helpers
+│   │
+│   └── types/
+│       └── index.ts                # TypeScript types mirroring backend shapes
+│
+├── .env.local.example              # Environment variable template
+├── next.config.ts                  # Next.js configuration (standalone output)
+├── tailwind.config.ts              # Tailwind CSS configuration
+├── tsconfig.json                   # TypeScript configuration (strict mode)
+├── .prettierrc                     # Prettier formatting rules
+├── eslint.config.mjs               # ESLint configuration
+└── Dockerfile                      # Multi-stage Docker build
 ```
 
 ---
 
-## 🤝 Contributing
+## Connecting to the Backend
 
-We welcome contributions.
-
-### How to Contribute
-
-1. Check open issues
-2. Create a new branch from `main`
-3. Follow conventional commit format
-4. Ensure:
-   - Code compiles
-   - Tests pass
-   - Formatting is clean (`cargo fmt`)
-   - Linting passes (`cargo clippy`)
-5. Open a Pull Request referencing the issue number
-
-Example:
-
-```
-feat(health): add horizon connectivity check
-```
-
-### Running Checks Before PR
+### Option A — Run the Rust backend locally
 
 ```bash
-cargo fmt
-cargo clippy
-cargo test
+# From the monorepo root
+cargo run -p core
+# Backend starts at http://localhost:4000
 ```
+
+Then set in your `.env.local`:
+```
+API_URL=http://localhost:4000
+```
+
+### Option B — Docker Compose (recommended)
+
+Runs both frontend and backend together:
+
+```bash
+# From the monorepo root
+docker compose up --build
+```
+
+- Frontend: `http://localhost:3000`
+- Backend: `http://localhost:4000`
+
+The frontend container connects to the backend via Docker's internal network using `http://backend:4000` — this is configured automatically in `docker-compose.yml`.
 
 ---
 
-## 📜 License
+## Architecture
 
-MIT (or project-specific license)
+### Proxy Pattern
+
+The frontend never calls the Stellar Explain backend directly from the browser. All API calls go through Next.js server-side proxy routes:
+
+```
+Browser → /api/tx/[hash] (Next.js server) → http://localhost:4000/tx/:hash (Rust backend)
+```
+
+This means `API_URL` is only ever read on the server — it is never bundled into the client JavaScript or exposed in network requests. This is intentional.
+
+### AppShell + Context
+
+All app pages (`/app`, `/tx/:hash`, `/account/:address`) are wrapped in `AppShell`, which provides shared state via React context. Child pages access shared state via `useAppShell()`:
+
+```tsx
+function TxPageInner() {
+  const { addEntry } = useAppShell();
+  ...
+}
+
+export default function TxPage() {
+  return (
+    <AppShell>
+      <TxPageInner />
+    </AppShell>
+  );
+}
+```
+
+### Route Structure
+
+| URL | Description |
+|-----|-------------|
+| `/` | Landing page |
+| `/app` | Search page — enter a hash or address |
+| `/tx/:hash` | Transaction explanation result |
+| `/account/:address` | Account explanation result |
+
+---
+
+## Contributing
+
+See the root [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+
+Before opening a PR, make sure:
+```bash
+npm run lint          # No TypeScript or ESLint errors
+npm run format:check  # Code is formatted correctly
+```

--- a/packages/ui/src/app/account/[address]/page.tsx
+++ b/packages/ui/src/app/account/[address]/page.tsx
@@ -1,76 +1,65 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { fetchAccount, getErrorMessage } from "@/lib/api";
-import type { AccountExplanation } from "@/types";
-import { AccountResult } from "@/components/AccountResult";
-import AppShell from "@/components/AppShell";
-import { useAppShell } from "@/components/AppShellContext";
-
-// ── Inner page — consumes context ──────────────────────────────────────────
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { fetchAccount } from '@/lib/api';
+import type { AccountExplanation } from '@/types';
+import { AccountResult } from '@/components/AccountResult';
+import ErrorDisplay from '@/components/ErrorDisplay';
+import AppShell from '@/components/AppShell';
+import { useAppShell } from '@/components/AppShellContext';
 
 function AccountPageInner() {
   const { address } = useParams<{ address: string }>();
   const router = useRouter();
-  const { addEntry, isSaved, getEntry, saveAddress, removeAddress } =
-    useAppShell();
+  const { addEntry, isSaved, getEntry, saveAddress, removeAddress } = useAppShell();
 
   const [data, setData] = useState<AccountExplanation | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
+  const load = useCallback(async () => {
     if (!address) return;
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await fetchAccount(address);
-        if (!cancelled) {
-          setData(result);
-          addEntry("account", address, result.summary);
-        }
-      } catch (err) {
-        if (!cancelled) setError(getErrorMessage(err));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchAccount(address);
+      setData(result);
+      addEntry('account', address, result.summary);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
     }
-
-    load();
-    return () => {
-      cancelled = true;
-    };
   }, [address, addEntry]);
 
+  useEffect(() => {
+    load();
+  }, [load]);
+
   return (
-    <div style={{ paddingTop: "24px" }}>
+    <div style={{ paddingTop: '24px' }}>
       {/* Back button */}
       <button
-        onClick={() => router.push("/app")}
+        onClick={() => router.push('/app')}
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "6px",
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          color: "rgba(255,255,255,0.3)",
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          color: 'rgba(255,255,255,0.3)',
           fontFamily: "'IBM Plex Sans', sans-serif",
-          fontSize: "12px",
-          padding: "0 0 20px",
-          transition: "color 0.15s ease",
+          fontSize: '12px',
+          padding: '0 0 20px',
+          transition: 'color 0.15s ease',
         }}
         onMouseEnter={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color =
-            "rgba(255,255,255,0.7)";
+          (e.currentTarget as HTMLButtonElement).style.color = 'rgba(255,255,255,0.7)';
         }}
         onMouseLeave={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color =
-            "rgba(255,255,255,0.3)";
+          (e.currentTarget as HTMLButtonElement).style.color = 'rgba(255,255,255,0.3)';
         }}
       >
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -86,13 +75,8 @@ function AccountPageInner() {
       </button>
 
       {loading && <AccountSkeleton />}
-     
 
-      {error && !loading && (
-        <div className="px-4 py-3 rounded-lg bg-red-900/20 border border-red-700/30 text-red-300 text-xs font-mono">
-          {error}
-        </div>
-      )}
+      {error && !loading && <ErrorDisplay error={error} identifier={address} onRetry={load} />}
 
       {data && !loading && (
         <AccountResult
@@ -110,8 +94,6 @@ function AccountPageInner() {
   );
 }
 
-// ── Page — wraps with AppShell ─────────────────────────────────────────────
-
 export default function AccountPage() {
   return (
     <AppShell>
@@ -120,62 +102,30 @@ export default function AccountPage() {
   );
 }
 
-// ── Skeleton ───────────────────────────────────────────────────────────────
-
 function AccountSkeleton() {
   return (
     <div className="space-y-4 animate-pulse">
       <div
         style={{
-          height: "16px",
-          width: "100px",
-          borderRadius: "6px",
-          background: "rgba(255,255,255,0.06)",
+          height: '16px',
+          width: '100px',
+          borderRadius: '6px',
+          background: 'rgba(255,255,255,0.06)',
         }}
       />
-      <div
-        style={{
-          height: "60px",
-          borderRadius: "12px",
-          background: "rgba(255,255,255,0.04)",
-        }}
-      />
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr 1fr",
-          gap: "12px",
-        }}
-      >
+      <div style={{ height: '60px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)' }} />
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '12px' }}>
         <div
-          style={{
-            height: "80px",
-            borderRadius: "12px",
-            background: "rgba(255,255,255,0.04)",
-          }}
+          style={{ height: '80px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)' }}
         />
         <div
-          style={{
-            height: "80px",
-            borderRadius: "12px",
-            background: "rgba(255,255,255,0.04)",
-          }}
+          style={{ height: '80px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)' }}
         />
         <div
-          style={{
-            height: "80px",
-            borderRadius: "12px",
-            background: "rgba(255,255,255,0.04)",
-          }}
+          style={{ height: '80px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)' }}
         />
       </div>
-      <div
-        style={{
-          height: "60px",
-          borderRadius: "12px",
-          background: "rgba(255,255,255,0.04)",
-        }}
-      />
+      <div style={{ height: '60px', borderRadius: '12px', background: 'rgba(255,255,255,0.04)' }} />
     </div>
   );
 }

--- a/packages/ui/src/app/layout.tsx
+++ b/packages/ui/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import "./globals.css";
+import NetworkStatusBanner from "@/components/NetworkStatusBanner";
 // import NetworkStatusBanner from "@/components/NetworkStatusBanner";
 
 const ibmPlexMono = IBM_Plex_Mono({
@@ -32,7 +33,7 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         {" "}
-        {/* <NetworkStatusBanner /> */}
+        <NetworkStatusBanner />
         {children}
       </body>
     </html>

--- a/packages/ui/src/app/tx/[hash]/page.tsx
+++ b/packages/ui/src/app/tx/[hash]/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { fetchTransaction, getErrorMessage } from "@/lib/api";
+import { fetchTransaction } from "@/lib/api";
 import type { TransactionExplanation } from "@/types";
 import { TransactionResult } from "@/components/TransactionResult";
+import ErrorDisplay from "@/components/ErrorDisplay";
 import AppShell from "@/components/AppShell";
 import { useAppShell } from "@/components/AppShellContext";
-
-// ── Inner page — consumes context ──────────────────────────────────────────
 
 function TxPageInner() {
   const { hash } = useParams<{ hash: string }>();
@@ -17,33 +16,26 @@ function TxPageInner() {
 
   const [data, setData] = useState<TransactionExplanation | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const load = useCallback(async () => {
+    if (!hash) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchTransaction(hash);
+      setData(result);
+      addEntry("transaction", hash, result.summary);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, [hash, addEntry]);
 
   useEffect(() => {
-    if (!hash) return;
-    let cancelled = false;
-
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await fetchTransaction(hash);
-        if (!cancelled) {
-          setData(result);
-          addEntry("transaction", hash, result.summary);
-        }
-      } catch (err) {
-        if (!cancelled) setError(getErrorMessage(err));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-
     load();
-    return () => {
-      cancelled = true;
-    };
-  }, [hash, addEntry]);
+  }, [load]);
 
   return (
     <div style={{ paddingTop: "24px" }}>
@@ -64,41 +56,30 @@ function TxPageInner() {
           transition: "color 0.15s ease",
         }}
         onMouseEnter={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color =
-            "rgba(255,255,255,0.7)";
+          (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.7)";
         }}
         onMouseLeave={(e) => {
-          (e.currentTarget as HTMLButtonElement).style.color =
-            "rgba(255,255,255,0.3)";
+          (e.currentTarget as HTMLButtonElement).style.color = "rgba(255,255,255,0.3)";
         }}
       >
         <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-          <path
-            d="M8 2L4 6l4 4"
-            stroke="currentColor"
-            strokeWidth="1.3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
+          <path d="M8 2L4 6l4 4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
         Back to search
       </button>
 
       {loading && <TransactionSkeleton />}
-     
 
       {error && !loading && (
-        <div className="px-4 py-3 rounded-lg bg-red-900/20 border border-red-700/30 text-red-300 text-xs font-mono">
-          {error}
-        </div>
+        <ErrorDisplay error={error} identifier={hash} onRetry={load} />
       )}
 
-      {data && !loading && <TransactionResult data={data} />}
+      {data && !loading && (
+        <TransactionResult data={data} />
+      )}
     </div>
   );
 }
-
-// ── Page — wraps with AppShell ─────────────────────────────────────────────
 
 export default function TxPage() {
   return (
@@ -108,50 +89,15 @@ export default function TxPage() {
   );
 }
 
-// ── Skeleton ───────────────────────────────────────────────────────────────
-
 function TransactionSkeleton() {
   return (
     <div className="space-y-4 animate-pulse">
-      <div
-        style={{
-          height: "16px",
-          width: "120px",
-          borderRadius: "6px",
-          background: "rgba(255,255,255,0.06)",
-        }}
-      />
-      <div
-        style={{
-          height: "60px",
-          borderRadius: "12px",
-          background: "rgba(255,255,255,0.04)",
-        }}
-      />
-      <div
-        style={{
-          height: "80px",
-          borderRadius: "12px",
-          background: "rgba(255,255,255,0.04)",
-        }}
-      />
-      <div
-        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}
-      >
-        <div
-          style={{
-            height: "72px",
-            borderRadius: "12px",
-            background: "rgba(255,255,255,0.04)",
-          }}
-        />
-        <div
-          style={{
-            height: "72px",
-            borderRadius: "12px",
-            background: "rgba(255,255,255,0.04)",
-          }}
-        />
+      <div style={{ height: "16px", width: "120px", borderRadius: "6px", background: "rgba(255,255,255,0.06)" }} />
+      <div style={{ height: "60px", borderRadius: "12px", background: "rgba(255,255,255,0.04)" }} />
+      <div style={{ height: "80px", borderRadius: "12px", background: "rgba(255,255,255,0.04)" }} />
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px" }}>
+        <div style={{ height: "72px", borderRadius: "12px", background: "rgba(255,255,255,0.04)" }} />
+        <div style={{ height: "72px", borderRadius: "12px", background: "rgba(255,255,255,0.04)" }} />
       </div>
     </div>
   );

--- a/packages/ui/src/components/ErrorDisplay.tsx
+++ b/packages/ui/src/components/ErrorDisplay.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { isApiError } from "@/lib/errors";
+import type { ApiError } from "@/types";
+
+interface Props {
+  error: ApiError | Error | unknown;
+  identifier?: string; // hash or address — used in NOT_FOUND message
+  onRetry?: () => void;
+}
+
+export default function ErrorDisplay({ error, identifier, onRetry }: Props) {
+  const { title, message, showRetry } = resolveError(error, identifier);
+
+  return (
+    <div
+      style={{
+        padding: "16px 20px",
+        borderRadius: "12px",
+        background: "rgba(239,68,68,0.06)",
+        border: "1px solid rgba(239,68,68,0.2)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "8px",
+      }}
+    >
+      {/* Icon + title row */}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="none"
+          style={{ flexShrink: 0 }}
+        >
+          <circle cx="7" cy="7" r="6" stroke="rgba(239,68,68,0.7)" strokeWidth="1.2" />
+          <line
+            x1="7" y1="4" x2="7" y2="7.5"
+            stroke="rgba(239,68,68,0.7)"
+            strokeWidth="1.3"
+            strokeLinecap="round"
+          />
+          <circle cx="7" cy="9.5" r="0.7" fill="rgba(239,68,68,0.7)" />
+        </svg>
+        <p
+          style={{
+            margin: 0,
+            fontFamily: "'IBM Plex Mono', monospace",
+            fontSize: "11px",
+            fontWeight: 600,
+            color: "rgba(239,68,68,0.8)",
+            letterSpacing: "0.04em",
+          }}
+        >
+          {title}
+        </p>
+      </div>
+
+      {/* Message */}
+      <p
+        style={{
+          margin: 0,
+          fontFamily: "'IBM Plex Sans', sans-serif",
+          fontSize: "13px",
+          color: "rgba(255,255,255,0.6)",
+          lineHeight: 1.5,
+        }}
+      >
+        {message}
+      </p>
+
+      {/* Retry button */}
+      {showRetry && onRetry && (
+        <button
+          onClick={onRetry}
+          style={{
+            alignSelf: "flex-start",
+            marginTop: "4px",
+            padding: "6px 14px",
+            borderRadius: "8px",
+            border: "1px solid rgba(239,68,68,0.25)",
+            background: "rgba(239,68,68,0.08)",
+            color: "rgba(239,68,68,0.8)",
+            fontFamily: "'IBM Plex Sans', sans-serif",
+            fontSize: "12px",
+            fontWeight: 500,
+            cursor: "pointer",
+            transition: "all 0.15s ease",
+          }}
+          onMouseEnter={(e) => {
+            const btn = e.currentTarget as HTMLButtonElement;
+            btn.style.background = "rgba(239,68,68,0.15)";
+            btn.style.color = "rgba(239,68,68,1)";
+          }}
+          onMouseLeave={(e) => {
+            const btn = e.currentTarget as HTMLButtonElement;
+            btn.style.background = "rgba(239,68,68,0.08)";
+            btn.style.color = "rgba(239,68,68,0.8)";
+          }}
+        >
+          Try again
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Error resolution logic ─────────────────────────────────────────────────
+
+interface Resolved {
+  title: string;
+  message: string;
+  showRetry: boolean;
+}
+
+function resolveError(error: unknown, identifier?: string): Resolved {
+  if (isApiError(error)) {
+    const message = error.error.message;
+    switch (error.error.code) {
+      case "NOT_FOUND":
+        return {
+          title: "NOT FOUND",
+          message: identifier
+            ? `"${truncate(identifier)}" was not found on the Stellar network. Check the value and try again.`
+            : "This was not found on the Stellar network. Check the value and try again.",
+          showRetry: false,
+        };
+      case "UPSTREAM_ERROR":
+        return {
+          title: "NETWORK ERROR",
+          message: "Stellar network is temporarily unreachable — please try again in a moment.",
+          showRetry: true,
+        };
+      case "BAD_REQUEST":
+        return {
+          title: "INVALID REQUEST",
+          message: message ?? "Bad request — please check your input.",
+          showRetry: false,
+        };
+      default:
+        return {
+          title: "ERROR",
+          message: message ?? "Something went wrong. Please try again.",
+          showRetry: true,
+        };
+    }
+  }
+
+  if (error instanceof Error) {
+    return {
+      title: "ERROR",
+      message: error.message || "Something went wrong. Please try again.",
+      showRetry: true,
+    };
+  }
+
+  return {
+    title: "ERROR",
+    message: "Something went wrong. Please try again.",
+    showRetry: true,
+  };
+}
+
+function truncate(value: string): string {
+  if (value.length <= 16) return value;
+  return `${value.slice(0, 8)}…${value.slice(-8)}`;
+}

--- a/packages/ui/src/components/NetworkStatusBanner.tsx
+++ b/packages/ui/src/components/NetworkStatusBanner.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { fetchHealth } from "@/lib/api";
+
+const POLL_INTERVAL = 60_000; // 60 seconds
+
+export default function NetworkStatusBanner() {
+  const [degraded, setDegraded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  const check = useCallback(async () => {
+    try {
+      const health = await fetchHealth();
+      const isOk = health.status === "ok" && health.horizon_reachable;
+    // const isOk = false;
+      setDegraded(!isOk);
+      // If network recovered, un-dismiss so banner can show again if it degrades later
+      if (isOk) setDismissed(false);
+    } catch {
+      // fetch failed entirely — treat as degraded
+      setDegraded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    // Run immediately on mount, non-blocking
+    check();
+    const interval = setInterval(check, POLL_INTERVAL);
+    return () => clearInterval(interval);
+  }, [check]);
+
+  if (!degraded || dismissed) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        position: "sticky",
+        top: 0,
+        zIndex: 100,
+        width: "100%",
+        backgroundColor: "#451a03",
+        borderBottom: "1px solid #92400e",
+        padding: "10px 20px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "12px",
+        fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "10px",
+          flex: 1,
+        }}
+      >
+        {/* Warning icon */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ flexShrink: 0 }}
+        >
+          <path
+            d="M8 1.5L14.5 13H1.5L8 1.5Z"
+            stroke="#fbbf24"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+          <line x1="8" y1="6" x2="8" y2="9.5" stroke="#fbbf24" strokeWidth="1.2" strokeLinecap="round" />
+          <circle cx="8" cy="11.5" r="0.7" fill="#fbbf24" />
+        </svg>
+
+        <p
+          style={{
+            margin: 0,
+            fontSize: "13px",
+            color: "#fde68a",
+            lineHeight: 1.4,
+          }}
+        >
+          <span style={{ fontWeight: 500 }}>Stellar network connectivity is degraded.</span>
+          {" "}Explanations may be unavailable or slower than usual.
+        </p>
+      </div>
+
+      {/* Dismiss button */}
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss network warning"
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: "4px",
+          color: "#fbbf24",
+          opacity: 0.7,
+          flexShrink: 0,
+          lineHeight: 1,
+        }}
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <line x1="2" y1="2" x2="12" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="12" y1="2" x2="2" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/packages/ui/src/lib/env.ts
+++ b/packages/ui/src/lib/env.ts
@@ -1,0 +1,53 @@
+/**
+ * Environment variable validation.
+ *
+ * Import this module anywhere env vars are needed.
+ * In development: throws a clear error if required vars are missing.
+ * In production: logs a warning and falls back to safe defaults.
+ */
+
+const isDev = process.env.NODE_ENV === 'development';
+
+function requireEnv(key: string, fallback: string): string {
+  const value = process.env[key];
+
+  if (!value) {
+    const message = [
+      `[Stellar Explain] Missing environment variable: ${key}`,
+      `  Copy .env.local.example to .env.local and set ${key}.`,
+      `  Falling back to: "${fallback}"`,
+    ].join('\n');
+
+    if (isDev) {
+      throw new Error(message);
+    } else {
+      console.warn(message);
+      return fallback;
+    }
+  }
+
+  return value;
+}
+
+function optionalEnv(key: string, fallback: string): string {
+  return process.env[key] ?? fallback;
+}
+
+// ── Validated variables ────────────────────────────────────────────────────
+
+/**
+ * The base URL of the Rust backend.
+ * Server-side only — never exposed to the browser.
+ * Set via API_URL in .env.local.
+ */
+export const API_URL = requireEnv('API_URL', 'http://localhost:4000');
+
+/**
+ * The active Stellar network.
+ * Used for display purposes in the UI (e.g. network badge in Navbar).
+ * Must be 'mainnet' or 'testnet'.
+ */
+export const STELLAR_NETWORK = optionalEnv(
+  'NEXT_PUBLIC_STELLAR_NETWORK',
+  'testnet',
+) as 'mainnet' | 'testnet';


### PR DESCRIPTION
## Summary

Covers error handling polish, developer experience tooling, and documentation.
All four issues are grouped as they are non-blocking quality improvements
that don't depend on each other.

## Changes

### UI #17 — Shared ErrorDisplay component
- `src/components/ErrorDisplay.tsx` — typed error display accepting `ApiError | Error`
- `NOT_FOUND` → contextual message with truncated identifier
- `UPSTREAM_ERROR` → network unreachable message with retry button
- `BAD_REQUEST` → displays backend message directly
- Unknown errors → generic fallback with retry button
- `src/app/tx/[hash]/page.tsx` — replaced inline error div with `ErrorDisplay`
- `src/app/account/[address]/page.tsx` — replaced inline error div with `ErrorDisplay`
- Error state refactored to `Error | null` to satisfy TypeScript strict mode
- `load` extracted to `useCallback` so retry can call it directly

### UI #18 — Network status banner
- `src/components/NetworkStatusBanner.tsx` — polls `GET /health` every 60s
- Shows sticky amber banner only when `status !== "ok"` or `horizon_reachable === false`
- Dismiss button hides for session, auto-recovers on next poll
- Non-blocking — never delays page render
- Wired into `src/app/layout.tsx`

### UI #19 — Environment variable validation
- `src/lib/env.ts` — `requireEnv()` throws in dev if missing, warns in prod
- `API_URL` validated before any proxy route runs
- All three proxy routes updated to import `API_URL` from `@/lib/env`
- `.env.local.example` updated with all variables documented

### UI #20 — Frontend README
- `packages/ui/README.md` — full rewrite (previous file contained backend Rust docs)
- Covers: prerequisites, setup steps, all env vars, all scripts, full project
  structure, connecting to backend (Cargo and Docker), architecture notes
  (proxy pattern, AppShell context, route table)

## How to test
```bash
npm install
cp .env.local.example .env.local
npm run dev

# Env validation: remove API_URL from .env.local → dev server should error
# Network banner: stop the backend → amber banner appears within 60s
# Error display: enter an invalid hash → NOT_FOUND error renders correctly
# Retry button: enter a hash when backend is down → UPSTREAM_ERROR + retry
```

## Closes

Closes #165
Closes #166
Closes #167
Closes #168