### PR TITLE
feat(cli): scaffold CLI package — timeout, verbose, formatters

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "@stellar-explain/cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stellar-explain/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "commander": "12.1.0"
+      },
+      "bin": {
+        "stellar-explain": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "20.14.0",
+        "typescript": "5.4.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
+      "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@stellar-explain/cli",
+  "version": "0.1.0",
+  "description": "CLI for the Stellar Explain API",
+  "engines": { "node": ">=18.0.0" },
+  "bin": { "stellar-explain": "dist/index.js" },
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/index.js",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --write src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "commander": "12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.0",
+    "typescript": "5.4.5"
+  }
+}

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -1,0 +1,17 @@
+import type { Command } from "commander";
+import { createClient } from "../lib/client.js";
+import { validateAddress } from "../lib/validate.js";
+import { formatAccount } from "../formatters/account.js";
+
+export function registerAccount(program: Command): void {
+  program
+    .command("account <address>")
+    .description("Explain a Stellar account")
+    .action(async (address: string) => {
+      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
+      validateAddress(address);
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const acc = await client.getAccount(address);
+      console.log(opts.json ? JSON.stringify(acc, null, 2) : formatAccount(acc));
+    });
+}

--- a/packages/cli/src/commands/health.ts
+++ b/packages/cli/src/commands/health.ts
@@ -1,0 +1,17 @@
+import type { Command } from "commander";
+import { createClient } from "../lib/client.js";
+
+export function registerHealth(program: Command): void {
+  program
+    .command("health")
+    .description("Check API health status")
+    .action(async () => {
+      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const h = await client.getHealth();
+      if (opts.json) { console.log(JSON.stringify(h, null, 2)); return; }
+      console.log(`Status:   ${h.status}`);
+      console.log(`Horizon:  ${h.horizon_reachable ? "reachable" : "unreachable"}`);
+      console.log(`Version:  ${h.version}`);
+    });
+}

--- a/packages/cli/src/commands/tx.ts
+++ b/packages/cli/src/commands/tx.ts
@@ -1,0 +1,17 @@
+import type { Command } from "commander";
+import { createClient } from "../lib/client.js";
+import { validateHash } from "../lib/validate.js";
+import { formatTransaction } from "../formatters/transaction.js";
+
+export function registerTx(program: Command): void {
+  program
+    .command("tx <hash>")
+    .description("Explain a Stellar transaction")
+    .action(async (hash: string) => {
+      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
+      validateHash(hash);
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const tx = await client.getTransaction(hash);
+      console.log(opts.json ? JSON.stringify(tx, null, 2) : formatTransaction(tx));
+    });
+}

--- a/packages/cli/src/formatters/account.ts
+++ b/packages/cli/src/formatters/account.ts
@@ -1,0 +1,29 @@
+import type { AccountExplanation } from "../types/index.js";
+
+export function formatAccount(acc: AccountExplanation): string {
+  const lines: string[] = [
+    `Account:     ${acc.account_id}`,
+    `Summary:     ${acc.summary}`,
+    `Subentries:  ${acc.subentry_count}`,
+    `Last ledger: ${acc.last_modified_ledger}`,
+  ];
+
+  if (acc.home_domain) lines.push(`Home domain: ${acc.home_domain}`);
+
+  if (acc.balances.length > 0) {
+    lines.push("", "Balances:");
+    for (const b of acc.balances) {
+      const asset = b.asset_type === "native" ? "XLM" : `${b.asset_code ?? ""}:${b.asset_issuer ?? ""}`;
+      lines.push(`  ${b.balance}  ${asset}`);
+    }
+  }
+
+  if (acc.signers.length > 0) {
+    lines.push("", "Signers:");
+    for (const s of acc.signers) {
+      lines.push(`  ${s.key}  weight=${s.weight}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/formatters/transaction.ts
+++ b/packages/cli/src/formatters/transaction.ts
@@ -1,0 +1,26 @@
+import type { TransactionExplanation } from "../types/index.js";
+
+export function formatTransaction(tx: TransactionExplanation): string {
+  const lines: string[] = [
+    `Transaction: ${tx.hash}`,
+    `Status:      ${tx.status}`,
+    `Summary:     ${tx.summary}`,
+    `Ledger:      ${tx.ledger}`,
+    `Closed at:   ${tx.created_at}`,
+    `Fee:         ${tx.fee_charged} stroops`,
+  ];
+
+  if (tx.memo) lines.push(`Memo:        ${tx.memo}`);
+
+  if (tx.payments.length > 0) {
+    lines.push("", "Payments:");
+    for (const p of tx.payments) {
+      lines.push(`  ${p.from} → ${p.to}  ${p.amount} ${p.asset}`);
+    }
+  }
+
+  if (tx.skipped_operations > 0)
+    lines.push(``, `Skipped ops: ${tx.skipped_operations}`);
+
+  return lines.join("\n");
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import { Command } from "commander";
+import { resolveBaseUrl } from "./lib/config.js";
+import { registerTx } from "./commands/tx.js";
+import { registerAccount } from "./commands/account.js";
+import { registerHealth } from "./commands/health.js";
+import { InvalidInputError } from "./lib/errors.js";
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version } = require("../package.json") as { version: string };
+
+const program = new Command();
+
+program
+  .name("stellar-explain")
+  .version(version)
+  .option("--url <url>", "API base URL")
+  .option("--timeout <ms>", "Request timeout in ms", (v) => parseInt(v, 10), 10000) // #276
+  .option("--verbose", "Log request details to stderr", false)                       // #277
+  .option("--json", "Output raw JSON", false);
+
+// Resolve --url after parsing
+program.hook("preAction", (thisCommand) => {
+  const opts = thisCommand.opts<{ url?: string }>();
+  if (!opts.url) thisCommand.setOptionValue("url", resolveBaseUrl());
+});
+
+registerTx(program);
+registerAccount(program);
+registerHealth(program);
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  const code = err instanceof InvalidInputError ? 2 : 1;
+  process.stderr.write(`Error: ${msg}\n`);
+  process.exit(code);
+});

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,0 +1,53 @@
+import { NetworkError, NotFoundError } from "./errors.js";
+import type {
+  TransactionExplanation,
+  AccountExplanation,
+  HealthResponse,
+} from "../types/index.js";
+
+export interface ClientOptions {
+  baseUrl: string;
+  timeout: number;  // #276
+  verbose: boolean; // #277
+}
+
+async function request<T>(
+  url: string,
+  opts: ClientOptions,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts.timeout);
+  const start = Date.now();
+
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    const duration = Date.now() - start;
+
+    if (opts.verbose) {
+      process.stderr.write(`[verbose] ${url} ${res.status} ${duration}ms\n`);
+    }
+
+    if (res.status === 404) throw new NotFoundError(`Not found: ${url}`);
+    if (!res.ok) throw new NetworkError(`HTTP ${res.status}: ${url}`);
+
+    return res.json() as Promise<T>;
+  } catch (err) {
+    if (err instanceof NotFoundError || err instanceof NetworkError) throw err;
+    if ((err as Error).name === "AbortError")
+      throw new NetworkError(`Request timed out after ${opts.timeout}ms`);
+    throw new NetworkError(`Request failed: ${(err as Error).message}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function createClient(opts: ClientOptions) {
+  return {
+    getTransaction: (hash: string) =>
+      request<TransactionExplanation>(`${opts.baseUrl}/tx/${hash}`, opts),
+    getAccount: (address: string) =>
+      request<AccountExplanation>(`${opts.baseUrl}/account/${address}`, opts),
+    getHealth: () =>
+      request<HealthResponse>(`${opts.baseUrl}/health`, opts),
+  };
+}

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,0 +1,5 @@
+const DEFAULT_URL = "http://localhost:8080";
+
+export function resolveBaseUrl(flagUrl?: string): string {
+  return flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? DEFAULT_URL;
+}

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -1,0 +1,11 @@
+export class NotFoundError extends Error {
+  constructor(msg: string) { super(msg); this.name = "NotFoundError"; }
+}
+
+export class NetworkError extends Error {
+  constructor(msg: string) { super(msg); this.name = "NetworkError"; }
+}
+
+export class InvalidInputError extends Error {
+  constructor(msg: string) { super(msg); this.name = "InvalidInputError"; }
+}

--- a/packages/cli/src/lib/validate.ts
+++ b/packages/cli/src/lib/validate.ts
@@ -1,0 +1,11 @@
+import { InvalidInputError } from "./errors.js";
+
+export function validateHash(hash: string): void {
+  if (!/^[0-9a-fA-F]{64}$/.test(hash))
+    throw new InvalidInputError(`Invalid transaction hash: ${hash}`);
+}
+
+export function validateAddress(address: string): void {
+  if (!/^G[A-Z2-7]{55}$/.test(address))
+    throw new InvalidInputError(`Invalid Stellar address: ${address}`);
+}

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,0 +1,48 @@
+export interface PaymentExplanation {
+  from: string;
+  to: string;
+  amount: string;
+  asset: string;
+  summary: string;
+}
+
+export interface TransactionExplanation {
+  hash: string;
+  summary: string;
+  status: "success" | "failed";
+  ledger: number;
+  created_at: string;
+  fee_charged: string;
+  memo: string | null;
+  payments: PaymentExplanation[];
+  skipped_operations: number;
+}
+
+export interface AssetBalance {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  balance: string;
+}
+
+export interface Signer {
+  key: string;
+  weight: number;
+  type: string;
+}
+
+export interface AccountExplanation {
+  account_id: string;
+  summary: string;
+  last_modified_ledger: number;
+  subentry_count: number;
+  home_domain?: string;
+  balances: AssetBalance[];
+  signers: Signer[];
+}
+
+export interface HealthResponse {
+  status: "ok" | "degraded" | "down";
+  horizon_reachable: boolean;
+  version: string;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "module": "CommonJS",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Scaffolds `packages/cli/` and implements CLI issues #17–20.

**Changes:**
- `src/lib/client.ts` — fetch wrapper with `--timeout` (AbortController) and `--verbose` (stderr logging)
- `src/formatters/transaction.ts` — terminal formatter for transaction explanations
- `src/formatters/account.ts` — terminal formatter for account explanations
- Foundation: types, errors, validate, config, commands (tx/account/health), entry point

closes #276, 
closes #277, 
closes #278, 
closes #279