### PR TITLE
feat(cli): cache clear command, --no-cache flag, version command and Vitest setup

### DIFF
--- a/packages/cli/src/commands/cacheClear.ts
+++ b/packages/cli/src/commands/cacheClear.ts
@@ -1,0 +1,18 @@
+import type { Command } from "commander";
+import * as fs from "fs";
+import * as path from "path";
+
+const CACHE_DIR = path.join(
+  process.env["HOME"] ?? process.env["USERPROFILE"] ?? ".",
+  ".stellar-explain-cache"
+);
+
+export function registerCacheClear(program: Command): void {
+  program
+    .command("cache-clear")
+    .description("Delete all locally cached responses")
+    .action(() => {
+      if (fs.existsSync(CACHE_DIR)) fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+      console.log("Cache cleared.");
+    });
+}

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -1,0 +1,11 @@
+import type { Command } from "commander";
+
+export function registerVersion(program: Command, cliVersion: string, apiVersion?: string): void {
+  program
+    .command("version")
+    .description("Show CLI and API versions")
+    .action(() => {
+      console.log(`CLI: ${cliVersion}`);
+      if (apiVersion) console.log(`API: ${apiVersion}`);
+    });
+}

--- a/packages/cli/src/lib/noCache.ts
+++ b/packages/cli/src/lib/noCache.ts
@@ -1,0 +1,3 @@
+export function shouldSkipCache(flag: boolean | undefined): boolean {
+  return flag === true;
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Adds cache management commands, version info, and Vitest configuration for the CLI package.

closes #312
closes #313
closes #314
closes #315