### PR TITLE
feat(cli): add coverage, integration tests, CI job, and ESLint config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,36 @@ jobs:
 
       - name: Run tests
         run: cargo test --all-targets --all-features
+
+  cli:
+    name: CLI Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/cli/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint:check
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/packages/cli/.eslintrc.json
+++ b/packages/cli/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "no-console": "warn",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/explicit-function-return-type": "off"
+  },
+  "ignorePatterns": ["dist/", "coverage/", "node_modules/"]
+}

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+coverage/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,14 +14,21 @@
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",
+    "lint:check": "eslint src --ext .ts --max-warnings 0",
     "format": "prettier --write src",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "commander": "12.1.0"
   },
   "devDependencies": {
     "@types/node": "20.14.0",
+    "@typescript-eslint/eslint-plugin": "7.18.0",
+    "@typescript-eslint/parser": "7.18.0",
+    "@vitest/coverage-v8": "^4.1.5",
+    "eslint": "8.57.0",
     "typescript": "5.4.5",
     "vitest": "^4.1.5"
   }

--- a/packages/cli/tests/integration/cli.integration.test.ts
+++ b/packages/cli/tests/integration/cli.integration.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { createClient } from "../../src/lib/client.js";
+import { BASE_URL, VALID_TX_HASH, VALID_ACCOUNT_ID } from "./fixtures.js";
+
+const RUN = process.env.STELLAR_EXPLAIN_INTEGRATION === "true";
+
+const client = createClient({ baseUrl: BASE_URL, timeout: 10000, verbose: false });
+
+describe.skipIf(!RUN)("integration: health", () => {
+  it("GET /health returns ok status", async () => {
+    const res = await client.getHealth();
+    expect(res.status).toBe("ok");
+    expect(typeof res.horizon_reachable).toBe("boolean");
+    expect(typeof res.version).toBe("string");
+  });
+});
+
+describe.skipIf(!RUN)("integration: transaction", () => {
+  it("GET /tx/:hash returns a transaction explanation", async () => {
+    const res = await client.getTransaction(VALID_TX_HASH);
+    expect(res.hash).toBe(VALID_TX_HASH);
+    expect(typeof res.summary).toBe("string");
+    expect(["success", "failed"]).toContain(res.status);
+  });
+});
+
+describe.skipIf(!RUN)("integration: account", () => {
+  it("GET /account/:id returns an account explanation", async () => {
+    const res = await client.getAccount(VALID_ACCOUNT_ID);
+    expect(res.account_id).toBe(VALID_ACCOUNT_ID);
+    expect(typeof res.summary).toBe("string");
+    expect(Array.isArray(res.balances)).toBe(true);
+  });
+});

--- a/packages/cli/tests/integration/fixtures.ts
+++ b/packages/cli/tests/integration/fixtures.ts
@@ -1,0 +1,7 @@
+export const BASE_URL = "http://localhost:4000";
+
+export const VALID_TX_HASH =
+  "6bc97b244a6a2a5b8522c4e6e8e3b1f2d9a0c7e5f3b1d8a2c4e6f8b0d2a4c6e8";
+
+export const VALID_ACCOUNT_ID =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,5 +4,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    coverage: {
+      provider: "v8",
+      thresholds: {
+        lines: 75,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

Resolves #328, #329, #330, #331

### Close #328 — v8 coverage reporting
- `vitest.config.ts`: added `coverage` block with `provider: 'v8'` and 75% line threshold
- `package.json`: added `test:coverage` script and `@vitest/coverage-v8` devDep
- `.gitignore`: added `coverage/`

### Close #329 — Integration tests
- `tests/integration/fixtures.ts`: base URL and sample identifiers
- `tests/integration/cli.integration.test.ts`: health, transaction, and account tests using `describe.skipIf`, skipped unless `STELLAR_EXPLAIN_INTEGRATION=true`

### Close #330 — CI job
- `.github/workflows/ci.yml`: added `cli` job running lint, typecheck, test, and build for `packages/cli/`

### Close #331 — ESLint config
- `packages/cli/.eslintrc.json`: `@typescript-eslint` parser/plugin, `eslint:recommended` + `@typescript-eslint/recommended`, node env
- `package.json`: added `lint:check` script and ESLint devDeps (`eslint`, `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`)