### PR TITLE
cli: graceful error handling for edge cases

### DIFF
--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -12,8 +12,16 @@ export function registerWatch(program: Command): void {
       const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
       validateHash(hash);
       const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+
+      let cancelled = false;
+      process.on("SIGINT", () => {
+        cancelled = true;
+        process.stderr.write("\nWatch cancelled.\n");
+        process.exit(0);
+      });
+
       const deadline = Date.now() + cmdOpts.watchTimeout;
-      while (Date.now() < deadline) {
+      while (!cancelled && Date.now() < deadline) {
         const tx = await client.getTransaction(hash);
         if (opts.json) { console.log(JSON.stringify(tx, null, 2)); break; }
         console.log(tx);

--- a/packages/cli/src/lib/cache.ts
+++ b/packages/cli/src/lib/cache.ts
@@ -36,7 +36,12 @@ export function clearCache(): void {
 }
 
 export function setCache<T>(input: string, data: T): void {
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  } catch {
+    process.stderr.write(`[warn] Could not create cache directory ${CACHE_DIR} — skipping cache\n`);
+    return;
+  }
   const file = path.join(CACHE_DIR, cacheKey(input) + ".json");
   fs.writeFileSync(file, JSON.stringify(data), "utf8");
 }

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -28,7 +28,20 @@ async function request<T>(
     }
 
     if (res.status === 404) throw new NotFoundError(`Not found: ${url}`);
-    if (!res.ok) throw new NetworkError(`HTTP ${res.status}: ${url}`);
+    if (!res.ok) {
+      const contentType = res.headers.get("content-type") ?? "";
+      if (!contentType.includes("application/json")) {
+        const text = await res.text();
+        throw new NetworkError(`HTTP ${res.status}: non-JSON response — ${text.slice(0, 120)}`);
+      }
+      throw new NetworkError(`HTTP ${res.status}: ${url}`);
+    }
+
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.includes("application/json")) {
+      const text = await res.text();
+      throw new NetworkError(`Expected JSON but got: ${text.slice(0, 120)}`);
+    }
 
     return res.json() as Promise<T>;
   } catch (err) {

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -9,3 +9,10 @@ export class NetworkError extends Error {
 export class InvalidInputError extends Error {
   constructor(msg: string) { super(msg); this.name = "InvalidInputError"; }
 }
+
+export class NonJsonResponseError extends Error {
+  constructor(status: number, preview: string) {
+    super(`HTTP ${status}: non-JSON response — ${preview}`);
+    this.name = "NonJsonResponseError";
+  }
+}

--- a/packages/cli/src/lib/localConfig.ts
+++ b/packages/cli/src/lib/localConfig.ts
@@ -11,7 +11,13 @@ export interface LocalConfig {
 export function loadLocalConfig(): LocalConfig {
   const filePath = path.resolve(process.cwd(), CONFIG_FILE);
   if (!fs.existsSync(filePath)) return {};
-  return JSON.parse(fs.readFileSync(filePath, "utf8")) as LocalConfig;
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as LocalConfig;
+  } catch {
+    process.stderr.write(`[warn] Could not read ${CONFIG_FILE} — using defaults\n`);
+    return {};
+  }
 }
 
 export function saveLocalConfig(config: LocalConfig): void {


### PR DESCRIPTION
Closes #352, closes #353, closes #354, closes #355

- Non-JSON API responses (HTML error pages) now print a clear message instead of crashing on JSON parse
- SIGINT in the `watch` command exits cleanly with a message instead of a stack trace
- Malformed or unreadable `.stellar-explain.json` logs a warning and falls back to defaults
- Cache directory creation failure logs a warning and skips caching instead of crashing