### PR TITLE
cli: batch dry-run, HTTPS warn, node check, update check

### DIFF
--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -7,13 +7,26 @@ export function registerBatch(program: Command): void {
   program
     .command("batch <file>")
     .description("Explain multiple transaction hashes from a file")
-    .action(async (file: string) => {
+    .option("--dry-run", "Validate and list hashes without making API calls", false)
+    .action(async (file: string, cmdOpts: { dryRun: boolean }) => {
       const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
       const hashes = fs.readFileSync(file, "utf8").split("\n").map(h => h.trim()).filter(Boolean);
+
+      for (const hash of hashes) {
+        validateHash(hash);
+      }
+
+      if (cmdOpts.dryRun) {
+        process.stderr.write(`Dry run — ${hashes.length} hash(es) found, no API calls made:\n`);
+        for (const hash of hashes) {
+          process.stderr.write(`  ${hash}\n`);
+        }
+        return;
+      }
+
       const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
       const results: unknown[] = [];
       for (const hash of hashes) {
-        validateHash(hash);
         const tx = await client.getTransaction(hash);
         results.push(tx);
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,13 +1,25 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { resolveBaseUrl } from "./lib/config.js";
+import { runUpdateCheck } from "./lib/updateCheck.js";
 import { registerTx } from "./commands/tx.js";
 import { registerAccount } from "./commands/account.js";
 import { registerHealth } from "./commands/health.js";
+import { registerBatch } from "./commands/batch.js";
 import { InvalidInputError } from "./lib/errors.js";
+
+// #99 — Node version check
+const [major] = process.version.replace("v", "").split(".").map(Number);
+if (major < 18) {
+  process.stderr.write(`Error: Node.js 18 or higher is required (found ${process.version}).\n`);
+  process.exit(1);
+}
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { version } = require("../package.json") as { version: string };
+
+// #100 — Non-blocking update check
+runUpdateCheck(version);
 
 const program = new Command();
 
@@ -15,11 +27,10 @@ program
   .name("stellar-explain")
   .version(version)
   .option("--url <url>", "API base URL")
-  .option("--timeout <ms>", "Request timeout in ms", (v) => parseInt(v, 10), 10000) // #276
-  .option("--verbose", "Log request details to stderr", false)                       // #277
+  .option("--timeout <ms>", "Request timeout in ms", (v) => parseInt(v, 10), 10000)
+  .option("--verbose", "Log request details to stderr", false)
   .option("--json", "Output raw JSON", false);
 
-// Resolve --url after parsing
 program.hook("preAction", (thisCommand) => {
   const opts = thisCommand.opts<{ url?: string }>();
   if (!opts.url) thisCommand.setOptionValue("url", resolveBaseUrl());
@@ -28,6 +39,7 @@ program.hook("preAction", (thisCommand) => {
 registerTx(program);
 registerAccount(program);
 registerHealth(program);
+registerBatch(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,5 +1,25 @@
 const DEFAULT_URL = "http://localhost:8080";
 
+function isLocalhost(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+export function warnIfInsecure(url: string): void {
+  if (url.startsWith("http://") && !isLocalhost(url)) {
+    process.stderr.write(
+      `Warning: STELLAR_EXPLAIN_URL is set to a non-HTTPS URL (${url}). ` +
+      `Data will be transmitted over an insecure connection.\n`
+    );
+  }
+}
+
 export function resolveBaseUrl(flagUrl?: string): string {
-  return flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? DEFAULT_URL;
+  const url = flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? DEFAULT_URL;
+  warnIfInsecure(url);
+  return url;
 }

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -1,0 +1,44 @@
+import * as https from "https";
+
+const PACKAGE_NAME = "@stellar-explain/cli";
+const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+
+function fetchLatestVersion(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    https.get(REGISTRY_URL, (res) => {
+      let data = "";
+      res.on("data", (chunk: string) => { data += chunk; });
+      res.on("end", () => {
+        try {
+          const parsed = JSON.parse(data) as { version?: string };
+          if (parsed.version) resolve(parsed.version);
+          else reject(new Error("No version in registry response"));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    }).on("error", reject);
+  });
+}
+
+function isNewer(latest: string, current: string): boolean {
+  const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+  const [lMaj, lMin, lPat] = parse(latest);
+  const [cMaj, cMin, cPat] = parse(current);
+  if (lMaj !== cMaj) return lMaj > cMaj;
+  if (lMin !== cMin) return lMin > cMin;
+  return lPat > cPat;
+}
+
+export function runUpdateCheck(currentVersion: string): void {
+  fetchLatestVersion()
+    .then((latest) => {
+      if (isNewer(latest, currentVersion)) {
+        process.stderr.write(
+          `\nNotice: A newer version of ${PACKAGE_NAME} is available (${latest}). ` +
+          `Run \`npm install -g ${PACKAGE_NAME}\` to update.\n\n`
+        );
+      }
+    })
+    .catch(() => { /* silently ignore — must not block or crash */ });
+}


### PR DESCRIPTION
Closes #356 — adds `--dry-run` to `batch`: validates hashes and lists them without making any API calls.

Closes #357 — warns to stderr when `STELLAR_EXPLAIN_URL` is a non-localhost HTTP URL.

Closes #358 — exits with a clear error on startup if Node.js is below v18.

Closes #359 — adds `updateCheck.ts` that asynchronously checks npm for a newer CLI version and prints a notice; never blocks the command.