### PR TITLE
CLI wave: completion, config schema, changelog, usage summary

### DIFF
--- a/packages/cli/src/lib/changelog.ts
+++ b/packages/cli/src/lib/changelog.ts
@@ -1,0 +1,50 @@
+/**
+ * Changelog entry builder for @stellar-explain/cli.
+ * Generates structured release notes for CHANGELOG.md.
+ */
+
+export interface ChangelogEntry {
+  version: string;
+  date: string;
+  added?: string[];
+  fixed?: string[];
+  changed?: string[];
+}
+
+export function formatEntry(entry: ChangelogEntry): string {
+  const lines: string[] = [`## [${entry.version}] — ${entry.date}`, ""];
+
+  const section = (title: string, items?: string[]) => {
+    if (items && items.length > 0) {
+      lines.push(`### ${title}`);
+      items.forEach((item) => lines.push(`- ${item}`));
+      lines.push("");
+    }
+  };
+
+  section("Added", entry.added);
+  section("Changed", entry.changed);
+  section("Fixed", entry.fixed);
+
+  return lines.join("\n").trimEnd();
+}
+
+export const INITIAL_RELEASE: ChangelogEntry = {
+  version: "0.1.0",
+  date: "2026-04-28",
+  added: [
+    "`tx <hash>` — explain a Stellar transaction",
+    "`account <id>` — explain a Stellar account",
+    "`health` — check API health",
+    "`batch` — explain multiple transactions from a file",
+    "`watch <hash>` — poll a transaction until confirmed",
+    "`history` — view past lookups",
+    "`version` — print CLI version",
+    "`config get/set/list` — manage local config",
+    "`--url` global flag to target a custom API instance",
+    "`--json` global flag for raw JSON output",
+    "Local `.stellar-explain.json` config file support",
+    "Retry logic with exponential backoff",
+    "Cache layer for repeated lookups",
+  ],
+};

--- a/packages/cli/src/lib/completion.ts
+++ b/packages/cli/src/lib/completion.ts
@@ -1,18 +1,57 @@
-export function bashCompletion(binaryName: string): string {
-  return `# bash completion for ${binaryName}
-_${binaryName}_completions() {
+/**
+ * Shell completion helpers for stellar-explain CLI.
+ * Generates bash/zsh completion scripts via the `completion` command.
+ */
+
+const COMMANDS = ["tx", "account", "health", "batch", "watch", "history", "version", "config"];
+const FLAGS = ["--url", "--json", "--help", "--version"];
+
+export type Shell = "bash" | "zsh";
+
+function bashCompletion(bin: string): string {
+  const cmds = COMMANDS.join(" ");
+  const flags = FLAGS.join(" ");
+  return `
+_${bin}_completions() {
   local cur="\${COMP_WORDS[COMP_CWORD]}"
-  COMPREPLY=($(compgen -W "tx account health batch watch config version" -- "$cur"))
+  local commands="${cmds}"
+  local flags="${flags}"
+  if [[ "\${cur}" == -* ]]; then
+    COMPREPLY=( $(compgen -W "\${flags}" -- "\${cur}") )
+  else
+    COMPREPLY=( $(compgen -W "\${commands}" -- "\${cur}") )
+  fi
 }
-complete -F _${binaryName}_completions ${binaryName}`;
+complete -F _${bin}_completions ${bin}
+`.trim();
 }
 
-export function zshCompletion(binaryName: string): string {
-  return `#compdef ${binaryName}
-_${binaryName}() {
-  local -a cmds
-  cmds=(tx account health batch watch config version)
-  _describe "commands" cmds
+function zshCompletion(bin: string): string {
+  const cmds = COMMANDS.map((c) => `'${c}'`).join(" ");
+  return `
+#compdef ${bin}
+_${bin}() {
+  local -a commands
+  commands=(${cmds})
+  _arguments \\
+    '--url[API base URL]:url:' \\
+    '--json[Output raw JSON]' \\
+    '1: :->command'
+  case \$state in
+    command) _describe 'command' commands ;;
+  esac
 }
-_${binaryName}`;
+_${bin} "\$@"
+`.trim();
+}
+
+export function generateCompletion(shell: Shell, bin = "stellar-explain"): string {
+  return shell === "bash" ? bashCompletion(bin) : zshCompletion(bin);
+}
+
+export function installInstructions(shell: Shell, bin = "stellar-explain"): string {
+  if (shell === "bash") {
+    return `${bin} completion bash >> ~/.bash_completion && source ~/.bash_completion`;
+  }
+  return `${bin} completion zsh > "\${fpath[1]}/_${bin}" && exec zsh`;
 }

--- a/packages/cli/src/lib/configSchema.ts
+++ b/packages/cli/src/lib/configSchema.ts
@@ -1,0 +1,53 @@
+/**
+ * Schema definition and validator for .stellar-explain.json local config.
+ *
+ * Supported fields:
+ *   url     — Base URL of the Stellar Explain API (string, optional)
+ *   timeout — Request timeout in milliseconds (number, optional)
+ */
+
+export interface LocalConfigSchema {
+  url?: string;
+  timeout?: number;
+}
+
+export type ValidationResult =
+  | { valid: true; config: LocalConfigSchema }
+  | { valid: false; errors: string[] };
+
+const URL_RE = /^https?:\/\/.+/;
+
+export function validateLocalConfig(raw: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { valid: false, errors: ["Config must be a JSON object"] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if ("url" in obj) {
+    if (typeof obj.url !== "string" || !URL_RE.test(obj.url)) {
+      errors.push("`url` must be a valid http/https URL string");
+    }
+  }
+
+  if ("timeout" in obj) {
+    if (typeof obj.timeout !== "number" || obj.timeout <= 0 || !Number.isInteger(obj.timeout)) {
+      errors.push("`timeout` must be a positive integer (milliseconds)");
+    }
+  }
+
+  const known = new Set(["url", "timeout"]);
+  for (const key of Object.keys(obj)) {
+    if (!known.has(key)) errors.push(`Unknown field: \`${key}\``);
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+  return { valid: true, config: obj as LocalConfigSchema };
+}
+
+export const CONFIG_EXAMPLE: LocalConfigSchema = {
+  url: "http://localhost:3000",
+  timeout: 5000,
+};

--- a/packages/cli/src/lib/usageSummary.ts
+++ b/packages/cli/src/lib/usageSummary.ts
@@ -1,0 +1,52 @@
+/**
+ * Generates a plain-text CLI usage summary for embedding in README files.
+ * Used to keep the root monorepo README in sync with available commands.
+ */
+
+export interface CommandDef {
+  name: string;
+  args?: string;
+  description: string;
+}
+
+const COMMANDS: CommandDef[] = [
+  { name: "tx", args: "<hash>", description: "Explain a transaction" },
+  { name: "account", args: "<id>", description: "Explain an account" },
+  { name: "health", description: "Check API health" },
+  { name: "batch", args: "<file>", description: "Explain transactions from a file" },
+  { name: "watch", args: "<hash>", description: "Poll a transaction until confirmed" },
+  { name: "history", description: "View past lookups" },
+  { name: "version", description: "Print CLI version" },
+  { name: "config get/set/list", description: "Manage local config" },
+];
+
+export function usageSummary(bin = "stellar-explain"): string {
+  const pad = Math.max(...COMMANDS.map((c) => (c.args ? `${c.name} ${c.args}` : c.name).length));
+  const rows = COMMANDS.map((c) => {
+    const label = c.args ? `${c.name} ${c.args}` : c.name;
+    return `  ${bin} ${label.padEnd(pad)}  ${c.description}`;
+  });
+  return rows.join("\n");
+}
+
+export function installSnippet(pkg = "@stellar-explain/cli"): string {
+  return `npm install -g ${pkg}`;
+}
+
+export function readmeSection(bin = "stellar-explain", pkg = "@stellar-explain/cli"): string {
+  return [
+    "## CLI",
+    "",
+    "```sh",
+    installSnippet(pkg),
+    "```",
+    "",
+    "**Commands**",
+    "",
+    "```",
+    usageSummary(bin),
+    "```",
+    "",
+    `Use \`${bin} <command> --help\` for details on any command.`,
+  ].join("\n");
+}


### PR DESCRIPTION
Closes #348, closes #349, closes #350, closes #351

Adds four TypeScript helpers to support the CLI documentation issues:

- `usageSummary.ts` — generates the CLI section for the root README (#348)
- `changelog.ts` — structured 0.1.0 release entry builder for CHANGELOG.md (#349)
- `configSchema.ts` — schema definition and validator for `.stellar-explain.json` (#350)
- `completion.ts` — bash/zsh completion script generator with install instructions (#351)