### PR TITLE
cli: smoke test, workspace config, readme gen, contributing guide

### DIFF
--- a/packages/cli/src/lib/contributingGuide.ts
+++ b/packages/cli/src/lib/contributingGuide.ts
@@ -1,0 +1,45 @@
+interface Section {
+  title: string;
+  steps: string[];
+}
+
+const GUIDE: Section[] = [
+  {
+    title: "Local Setup",
+    steps: [
+      "Clone the repo and run `npm install` from the monorepo root.",
+      "Navigate to `packages/cli` and run `npm run build`.",
+      "Use `npm run dev` to watch for TypeScript changes.",
+    ],
+  },
+  {
+    title: "Running Tests",
+    steps: [
+      "Run `npm test` inside `packages/cli` to execute the Vitest suite.",
+      "Run `npm run typecheck` to verify types without emitting output.",
+      "All tests must pass before opening a pull request.",
+    ],
+  },
+  {
+    title: "Coding Conventions",
+    steps: [
+      "Use TypeScript strict mode — no implicit `any`.",
+      "Keep functions small and single-purpose.",
+      "Prefer named exports over default exports.",
+      "Add a test for every new public function.",
+    ],
+  },
+];
+
+function renderSection(section: Section): string {
+  const items = section.steps.map((s) => `- ${s}`).join("\n");
+  return `## ${section.title}\n\n${items}`;
+}
+
+export function generateContributingGuide(): string {
+  return GUIDE.map(renderSection).join("\n\n");
+}
+
+export function getSectionTitles(): string[] {
+  return GUIDE.map((s) => s.title);
+}

--- a/packages/cli/src/lib/readmeGen.ts
+++ b/packages/cli/src/lib/readmeGen.ts
@@ -1,0 +1,48 @@
+interface CommandDoc {
+  name: string;
+  description: string;
+  flags?: string[];
+  example: string;
+}
+
+const COMMANDS: CommandDoc[] = [
+  {
+    name: "tx <hash>",
+    description: "Fetch and explain a Stellar transaction by hash.",
+    flags: ["--url <url>", "--json", "--no-cache"],
+    example: "stellar-explain tx ABC123...",
+  },
+  {
+    name: "account <address>",
+    description: "Explain a Stellar account and its recent activity.",
+    flags: ["--url <url>", "--json", "--limit <n>"],
+    example: "stellar-explain account GABC...",
+  },
+  {
+    name: "health",
+    description: "Check whether the backend API is reachable.",
+    flags: ["--url <url>"],
+    example: "stellar-explain health",
+  },
+  {
+    name: "config set <key> <value>",
+    description: "Persist a configuration value.",
+    example: "stellar-explain config set url http://localhost:3000",
+  },
+  {
+    name: "history",
+    description: "List recently explained transactions.",
+    flags: ["--limit <n>", "--clear"],
+    example: "stellar-explain history --limit 5",
+  },
+];
+
+function renderCommand(cmd: CommandDoc): string {
+  const flags = cmd.flags ? `\n  Flags: ${cmd.flags.join(", ")}` : "";
+  return `### \`${cmd.name}\`\n${cmd.description}${flags}\n\`\`\`\n${cmd.example}\n\`\`\``;
+}
+
+export function generateReadme(): string {
+  const sections = COMMANDS.map(renderCommand).join("\n\n");
+  return `# stellar-explain CLI\n\n## Commands\n\n${sections}\n`;
+}

--- a/packages/cli/src/lib/smokeTest.ts
+++ b/packages/cli/src/lib/smokeTest.ts
@@ -1,0 +1,48 @@
+import { execSync } from "child_process";
+
+const BINARY = "node dist/index.js";
+const BASE_URL = process.env.STELLAR_EXPLAIN_URL ?? "http://localhost:3000";
+
+interface SmokeResult {
+  command: string;
+  passed: boolean;
+  output: string;
+}
+
+function run(cmd: string): SmokeResult {
+  try {
+    const output = execSync(`${BINARY} ${cmd} --url ${BASE_URL}`, {
+      encoding: "utf8",
+      timeout: 10_000,
+    }).trim();
+    return { command: cmd, passed: true, output };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { command: cmd, passed: false, output: msg };
+  }
+}
+
+function printResult(result: SmokeResult): void {
+  const icon = result.passed ? "✓" : "✗";
+  console.log(`${icon}  ${result.command}`);
+  if (!result.passed) console.error(`   ${result.output}`);
+}
+
+export function runSmokeTests(): void {
+  const cases = ["--version", "health"];
+  const results = cases.map(run);
+
+  results.forEach(printResult);
+
+  const failed = results.filter((r) => !r.passed);
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} smoke test(s) failed.`);
+    process.exit(1);
+  }
+
+  console.log("\nAll smoke tests passed.");
+}
+
+if (require.main === module) {
+  runSmokeTests();
+}

--- a/packages/cli/src/lib/workspaceConfig.ts
+++ b/packages/cli/src/lib/workspaceConfig.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+
+const EXPECTED_WORKSPACES = ["packages/cli", "packages/ui", "packages/core"];
+
+interface WorkspaceManifest {
+  name?: string;
+  workspaces?: string[];
+}
+
+function readRootManifest(root: string): WorkspaceManifest {
+  const pkgPath = path.join(root, "package.json");
+  if (!fs.existsSync(pkgPath)) {
+    throw new Error(`No package.json found at ${pkgPath}`);
+  }
+  return JSON.parse(fs.readFileSync(pkgPath, "utf8")) as WorkspaceManifest;
+}
+
+export function validateWorkspaces(root: string): void {
+  const manifest = readRootManifest(root);
+  const declared = manifest.workspaces ?? [];
+
+  const missing = EXPECTED_WORKSPACES.filter((ws) => !declared.includes(ws));
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing workspaces in root package.json: ${missing.join(", ")}`
+    );
+  }
+}
+
+export function listWorkspaces(root: string): string[] {
+  const manifest = readRootManifest(root);
+  return manifest.workspaces ?? [];
+}
+
+export function isCliRegistered(root: string): boolean {
+  const workspaces = listWorkspaces(root);
+  return workspaces.includes("packages/cli");
+}


### PR DESCRIPTION
Adds four TypeScript modules to close CLI wave issues 81–84.

- `smokeTest.ts` — runs `--version` and `health` against the built binary (closes #340)
- `workspaceConfig.ts` — validates and lists monorepo workspaces including `packages/cli` (closes #341)
- `readmeGen.ts` — generates the CLI README with all commands and flags (closes #342)
- `contributingGuide.ts` — renders local setup, test, and coding convention sections (closes #343)