### PR TITLE
cli: architecture ref, man page gen, troubleshooting guide, usage examples

### DIFF
--- a/packages/cli/scripts/generate-man.ts
+++ b/packages/cli/scripts/generate-man.ts
@@ -1,0 +1,58 @@
+/**
+ * Man page generator — issue #345
+ * Reads Commander help output and writes a Unix man page to man/stellar-explain.1
+ */
+
+import { execSync } from "child_process";
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const OUT_DIR = join(__dirname, "..", "man");
+const OUT_FILE = join(OUT_DIR, "stellar-explain.1");
+
+function getHelpText(): string {
+  try {
+    return execSync("node dist/index.js --help", { encoding: "utf8" });
+  } catch (e: any) {
+    return e.stdout ?? "";
+  }
+}
+
+function helpToMan(help: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const escaped = help
+    .replace(/\\/g, "\\\\")
+    .replace(/^-/gm, "\\-")
+    .replace(/'/g, "\\(aq");
+
+  return [
+    `.TH STELLAR-EXPLAIN 1 "${date}" "stellar-explain" "User Commands"`,
+    ".SH NAME",
+    "stellar-explain \\- explain Stellar blockchain transactions",
+    ".SH SYNOPSIS",
+    ".B stellar-explain",
+    "[command] [options]",
+    ".SH DESCRIPTION",
+    "Stellar Explain CLI fetches and explains Stellar transactions in plain English.",
+    ".SH OPTIONS",
+    ".nf",
+    escaped,
+    ".fi",
+    ".SH ENVIRONMENT",
+    ".TP",
+    ".B STELLAR_EXPLAIN_URL",
+    "Base URL of the Stellar Explain API (default: http://localhost:3000).",
+    ".SH SEE ALSO",
+    "Full docs: https://github.com/StellarCommons/Stellar-Explain",
+  ].join("\n");
+}
+
+function main(): void {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const help = getHelpText();
+  const man = helpToMan(help);
+  writeFileSync(OUT_FILE, man, "utf8");
+  console.log(`Man page written to ${OUT_FILE}`);
+}
+
+main();

--- a/packages/cli/src/examples/usage.ts
+++ b/packages/cli/src/examples/usage.ts
@@ -1,0 +1,45 @@
+/**
+ * CLI usage examples — issue #347
+ * Programmatic equivalents of the explain-tx, batch-from-file,
+ * and watch-pending shell script workflows.
+ */
+
+import { execSync, ExecSyncOptions } from "child_process";
+
+const RUN: ExecSyncOptions = { stdio: "inherit", encoding: "utf8" };
+
+/** Explain a single transaction by hash. */
+export function explainTx(hash: string, url?: string): void {
+  const env = url ? `STELLAR_EXPLAIN_URL=${url} ` : "";
+  execSync(`${env}stellar-explain tx ${hash}`, RUN);
+}
+
+/** Explain every hash listed in a plain-text file (one hash per line). */
+export function batchFromFile(filePath: string): void {
+  execSync(`stellar-explain batch --file ${filePath}`, RUN);
+}
+
+/** Watch a pending transaction until it is confirmed or times out. */
+export function watchPending(hash: string, intervalSec = 5): void {
+  execSync(`stellar-explain watch ${hash} --interval ${intervalSec}`, RUN);
+}
+
+/** Run all three example workflows in sequence (demo / smoke-test). */
+export function runAllExamples(): void {
+  const DEMO_HASH =
+    "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889";
+
+  console.log("--- explain single tx ---");
+  explainTx(DEMO_HASH);
+
+  console.log("\n--- batch from file ---");
+  batchFromFile("examples/hashes.txt");
+
+  console.log("\n--- watch pending tx ---");
+  watchPending(DEMO_HASH, 3);
+}
+
+// Run when executed directly: ts-node src/examples/usage.ts
+if (require.main === module) {
+  runAllExamples();
+}

--- a/packages/cli/src/lib/architecture.ts
+++ b/packages/cli/src/lib/architecture.ts
@@ -1,0 +1,53 @@
+/**
+ * CLI Architecture reference — issue #344
+ * Documents command flow, config resolution, cache strategy, and module layout.
+ */
+
+export const MODULE_LAYOUT = {
+  commands: "src/commands/   — one file per CLI subcommand",
+  formatters: "src/formatters/ — output renderers (text / JSON)",
+  lib: "src/lib/        — shared utilities (config, cache, network, errors)",
+  types: "src/types/      — shared TypeScript interfaces",
+} as const;
+
+export const COMMAND_FLOW: string[] = [
+  "1. bin/stellar-explain → src/index.ts (Commander root)",
+  "2. Commander parses argv and routes to the matching command file",
+  "3. Command validates flags via src/lib/validate.ts",
+  "4. Command calls src/lib/client.ts to hit the Stellar Explain API",
+  "5. Response is passed to the matching formatter",
+  "6. Formatter writes to stdout; errors go through src/lib/errorHandler.ts",
+];
+
+export const CONFIG_RESOLUTION_ORDER: string[] = [
+  "1. CLI flag  (--url, --no-cache, …)",
+  "2. Environment variable  (STELLAR_EXPLAIN_URL, …)",
+  "3. Local config file  (~/.stellar-explain/config.json)",
+  "4. Built-in default  (http://localhost:3000)",
+];
+
+export const CACHE_STRATEGY = {
+  store: "~/.stellar-explain/cache/",
+  keyScheme: "sha256(endpoint + serialisedParams)",
+  ttlSeconds: 300,
+  bypass: "--no-cache flag or STELLAR_EXPLAIN_NO_CACHE=1",
+  eviction: "stellar-explain cache clear",
+} as const;
+
+export function printArchitectureSummary(): void {
+  console.log("=== CLI Architecture ===\n");
+
+  console.log("Module layout:");
+  Object.values(MODULE_LAYOUT).forEach((line) => console.log(" ", line));
+
+  console.log("\nCommand flow:");
+  COMMAND_FLOW.forEach((step) => console.log(" ", step));
+
+  console.log("\nConfig resolution order:");
+  CONFIG_RESOLUTION_ORDER.forEach((rule) => console.log(" ", rule));
+
+  console.log("\nCache strategy:");
+  Object.entries(CACHE_STRATEGY).forEach(([k, v]) =>
+    console.log(`  ${k}: ${v}`)
+  );
+}

--- a/packages/cli/src/lib/troubleshooting.ts
+++ b/packages/cli/src/lib/troubleshooting.ts
@@ -1,0 +1,55 @@
+/**
+ * Troubleshooting reference — issue #346
+ * Common CLI problems and their fixes.
+ */
+
+export interface TroubleshootingEntry {
+  symptom: string;
+  cause: string;
+  fix: string;
+}
+
+export const KNOWN_ISSUES: TroubleshootingEntry[] = [
+  {
+    symptom: "Permission denied when running stellar-explain",
+    cause: "Binary is not executable after npm install",
+    fix: "Run: chmod +x $(which stellar-explain)",
+  },
+  {
+    symptom: "Error: STELLAR_EXPLAIN_URL is not set",
+    cause: "The CLI cannot find the API base URL",
+    fix: "Export the variable: export STELLAR_EXPLAIN_URL=http://localhost:3000",
+  },
+  {
+    symptom: "CORS error in browser / fetch blocked",
+    cause: "CORS is a browser concern; the CLI uses Node's http stack",
+    fix: "CORS does not apply to the CLI. Check that the server is reachable with: curl $STELLAR_EXPLAIN_URL/health",
+  },
+  {
+    symptom: "SyntaxError or 'require is not defined'",
+    cause: "Node version is too old (< 18)",
+    fix: "Upgrade Node: nvm install 18 && nvm use 18",
+  },
+  {
+    symptom: "stellar-explain: command not found",
+    cause: "Global npm bin directory is not in PATH",
+    fix: "Add npm bin to PATH: export PATH=$(npm bin -g):$PATH",
+  },
+];
+
+export function findIssue(keyword: string): TroubleshootingEntry | undefined {
+  const kw = keyword.toLowerCase();
+  return KNOWN_ISSUES.find(
+    (e) =>
+      e.symptom.toLowerCase().includes(kw) ||
+      e.cause.toLowerCase().includes(kw)
+  );
+}
+
+export function printAll(): void {
+  KNOWN_ISSUES.forEach(({ symptom, cause, fix }, i) => {
+    console.log(`\n[${i + 1}] ${symptom}`);
+    console.log(`    Cause: ${cause}`);
+    console.log(`    Fix:   ${fix}`);
+  });
+}


### PR DESCRIPTION
Closes #344, closes #345, closes #346, closes #347

- **architecture.ts** — documents command flow, config resolution order, cache strategy, and module layout (#344)
- **generate-man.ts** — script that reads Commander help output and writes `man/stellar-explain.1` (#345)
- **troubleshooting.ts** — typed catalogue of common CLI problems (permission denied, missing URL env var, old Node, etc.) with fixes (#346)
- **usage.ts** — programmatic equivalents of the explain-tx, batch-from-file, and watch-pending workflows (#347)