### PR TITLE
feat(cli): publish workflow, size check, lint-staged, dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/packages/cli"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "cli"
+    commit-message:
+      prefix: "chore(cli)"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,35 @@
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - "cli-v*"
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check binary size
+        run: npx ts-node scripts/check-size.ts
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/cli/lint-staged.config.ts
+++ b/packages/cli/lint-staged.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "lint-staged";
+
+/**
+ * lint-staged config for packages/cli
+ * Runs ESLint and Prettier on staged .ts files before commit.
+ */
+const config: Config = {
+  "src/**/*.ts": [
+    "eslint --fix --max-warnings=0",
+    "prettier --write",
+  ],
+  "scripts/**/*.ts": [
+    "eslint --fix --max-warnings=0",
+    "prettier --write",
+  ],
+  "*.{json,md,yml,yaml}": [
+    "prettier --write",
+  ],
+};
+
+export default config;

--- a/packages/cli/scripts/check-size.ts
+++ b/packages/cli/scripts/check-size.ts
@@ -1,0 +1,37 @@
+import { statSync } from "fs";
+import { resolve } from "path";
+
+const MAX_SIZE_BYTES = 500 * 1024; // 500 KB
+const DIST_FILE = resolve(__dirname, "../dist/index.js");
+
+function formatKB(bytes: number): string {
+  return (bytes / 1024).toFixed(1) + " KB";
+}
+
+function checkBinarySize(): void {
+  let stats;
+  try {
+    stats = statSync(DIST_FILE);
+  } catch {
+    console.error(`[check-size] File not found: ${DIST_FILE}`);
+    console.error("[check-size] Run 'npm run build' first.");
+    process.exit(1);
+  }
+
+  const { size } = stats;
+  const passed = size <= MAX_SIZE_BYTES;
+
+  console.log(`[check-size] dist/index.js — ${formatKB(size)}`);
+  console.log(`[check-size] Limit         — ${formatKB(MAX_SIZE_BYTES)}`);
+
+  if (!passed) {
+    console.error(
+      `[check-size] FAIL: binary exceeds limit by ${formatKB(size - MAX_SIZE_BYTES)}`
+    );
+    process.exit(1);
+  }
+
+  console.log("[check-size] PASS: binary is within the size limit.");
+}
+
+checkBinarySize();


### PR DESCRIPTION
Closes #336, closes #337, closes #338, closes #339

Adds four CLI tooling configs in one wave:

- **#336** — `.github/workflows/cli-publish.yml`: publishes to npm on `cli-v*` tag push
- **#337** — `packages/cli/scripts/check-size.ts`: fails CI if `dist/index.js` exceeds 500 KB
- **#338** — `packages/cli/lint-staged.config.ts`: runs ESLint + Prettier on staged `.ts` files pre-commit
- **#339** — `.github/dependabot.yml`: weekly npm dependency updates for `packages/cli/`