### PR TITLE
fix(ci): properly gate Release SDK steps when packages/sdk does not exist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ jobs:
   release:
     name: Release SDK
     runs-on: ubuntu-latest
-    # Only run when there is at least one .changeset/*.md file to process.
-    # The changesets/action below will either open a "Version Packages" PR
-    # (if unreleased changesets exist) or publish to npm (if the version PR
-    # was just merged and there are no pending changesets).
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -24,21 +20,39 @@ jobs:
           # Full history is required so changesets can diff tags correctly.
           fetch-depth: 0
 
+      # Gate all subsequent steps on packages/sdk existing.
+      # The SDK package has not been scaffolded yet; this prevents the job
+      # from crashing with "No such file or directory" on every push to main.
+      # Once packages/sdk/package.json is added, all steps below will run.
+      - name: Check if SDK package exists
+        id: sdk-check
+        run: |
+          if [ -f packages/sdk/package.json ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "packages/sdk not found — skipping SDK release"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup Node
+        if: steps.sdk-check.outputs.exists == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
       - name: Install SDK dependencies
+        if: steps.sdk-check.outputs.exists == 'true'
         run: npm ci
         working-directory: packages/sdk
 
       - name: Build SDK
+        if: steps.sdk-check.outputs.exists == 'true'
         run: npm run build
         working-directory: packages/sdk
 
       - name: Create Release PR or Publish to npm
+        if: steps.sdk-check.outputs.exists == 'true'
         uses: changesets/action@v1
         with:
           # Command that changesets/action calls when it decides to publish.


### PR DESCRIPTION
## Problem

The `Release / Release SDK` workflow crashes on every push to `main`:

```
Error: An error occurred trying to start process '/usr/bin/bash'
with working directory '.../packages/sdk'. No such file or directory
```

`packages/sdk` does not exist in the repo yet — the workflow was written ahead of the SDK package being scaffolded.

## Fix

Checkout runs first, then a `sdk-check` step tests whether `packages/sdk/package.json` exists and writes an output (`exists=true/false`). Every subsequent step is gated with `if: steps.sdk-check.outputs.exists == 'true'`.

- When `packages/sdk` is absent → job exits cleanly after the check step ✅
- When `packages/sdk` is added in future → all steps activate automatically with no further changes needed ✅

> Note: a job-level `if: hashFiles(...)` condition does not work here because `hashFiles()` is evaluated before checkout, so the workspace is always empty at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
