### PR TITLE
feat(deploy): Render blueprint + keep-alive cron for free-tier backend

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,30 @@
+name: Keep Backend Alive
+
+# Pings the Render backend every 5 minutes so the free-tier instance
+# does not spin down due to inactivity (Render sleeps after ~15 min).
+#
+# Setup: add BACKEND_URL as a GitHub Actions variable in the repo:
+#   Settings → Secrets and variables → Actions → Variables → New variable
+#   Name:  BACKEND_URL
+#   Value: https://stellar-explain-core.onrender.com   (your Render URL)
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch: # allow manual trigger from Actions tab
+
+jobs:
+  ping:
+    name: Ping /health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping backend health endpoint
+        run: |
+          echo "Pinging ${{ vars.BACKEND_URL }}/health ..."
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ vars.BACKEND_URL }}/health")
+          echo "Response: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "Warning: health check returned $STATUS"
+          else
+            echo "Backend is alive ✅"
+          fi

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: stellar-explain-core
+    runtime: docker
+    dockerfilePath: packages/core/Dockerfile
+    dockerContext: .
+    plan: free
+    healthCheckPath: /health
+    envVars:
+      - key: STELLAR_NETWORK
+        value: testnet
+      - key: HORIZON_URL
+        value: https://horizon-testnet.stellar.org
+      - key: CORS_ORIGIN
+        value: https://stellar-explain.vercel.app
+      - key: RUST_LOG
+        value: info


### PR DESCRIPTION
## What this adds

### `render.yaml` — One-click Render deployment
Render blueprint for the Rust backend. Deploying is as simple as connecting the repo on render.com — no manual config needed.

### `.github/workflows/keep-alive.yml` — Free-tier keep-alive ping
Render's free tier spins down after ~15 minutes of inactivity. This workflow pings `GET /health` every 5 minutes via GitHub Actions cron to keep the instance warm.

## Setup after merging

**1. Deploy on Render**
- Go to https://render.com → New → Blueprint → connect this repo
- Render picks up `render.yaml` automatically
- Note your service URL (e.g. `https://stellar-explain-core.onrender.com`)

**2. Update `CORS_ORIGIN`** in Render dashboard env vars to your actual frontend URL

**3. Add `BACKEND_URL` GitHub Actions variable**
- Repo → Settings → Secrets and variables → Actions → Variables → New variable
- Name: `BACKEND_URL`
- Value: `https://stellar-explain-core.onrender.com` (your Render URL)

The keep-alive cron starts firing automatically once the variable is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
