### PR TITLE
fix(docker): bump Rust base image to 1.88 to match CI toolchain

### DIFF
--- a/packages/core/Dockerfile
+++ b/packages/core/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build Stage ──────────────────────────────────────────────────────────────
-FROM rust:1.85-alpine AS builder
+FROM rust:1.88-alpine AS builder
 
 RUN apk add --no-cache \
     pkgconfig make musl-dev openssl-dev openssl-libs-static


### PR DESCRIPTION
The Dockerfile used `rust:1.85-alpine` but the codebase uses let-chains (stabilized in Rust 1.88), causing the Render deployment to fail at compile time. CI already pins `toolchain: 1.88.0` — Dockerfile now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
