### PR TITLE
feat(cli): add batch and watch commands

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -8,13 +8,15 @@
       "name": "@stellar-explain/cli",
       "version": "0.1.0",
       "dependencies": {
+        "cli-progress": "3.12.0",
         "commander": "12.1.0"
       },
       "bin": {
         "stellar-explain": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "20.14.0",
+        "@types/cli-progress": "3.11.6",
+        "@types/node": "22.15.0",
         "@typescript-eslint/eslint-plugin": "7.18.0",
         "@typescript-eslint/parser": "7.18.0",
         "@vitest/coverage-v8": "^4.1.5",
@@ -657,6 +659,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/cli-progress": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
+      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -672,13 +684,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.0.tgz",
-      "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "version": "22.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.0.tgz",
+      "integrity": "sha512-99S8dWD2DkeE6PBaEDw+In3aar7hdoBvjyJMR6vaKBTzpvR0P00ClzJMOoVrj9D2+Sy/YCwACYHnBTpMhg1UCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1042,7 +1054,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1170,6 +1181,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1288,6 +1311,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
@@ -1836,6 +1865,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2771,11 +2809,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -2967,9 +3018,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,8 @@
     "commander": "12.1.0"
   },
   "devDependencies": {
-    "@types/node": "20.14.0",
+    "@types/cli-progress": "3.11.6",
+    "@types/node": "22.15.0",
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "@vitest/coverage-v8": "^4.1.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "cli-progress": "3.12.0",
     "commander": "12.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -7,11 +7,12 @@ import { createClient } from "../lib/client.js";
 import { validateHash } from "../lib/validate.js";
 import { formatTransaction } from "../formatters/transaction.js";
 import { InvalidInputError } from "../lib/errors.js";
+import type { TransactionExplanation } from "../types/index.js";
 
 interface BatchResult {
   hash: string;
   status: "ok" | "error";
-  data?: unknown;
+  data?: TransactionExplanation;
   error?: string;
 }
 
@@ -125,7 +126,7 @@ export function registerBatch(program: Command): void {
         process.stdout.write(`\n— ${result.hash}\n`);
         if (result.status === "error") {
           process.stderr.write(`  Error: ${result.error}\n`);
-        } else {
+        } else if (result.data !== undefined) {
           console.log(formatTransaction(result.data));
         }
       }

--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -1,35 +1,133 @@
+import fs from "fs";
+import path from "path";
+import readline from "readline";
 import type { Command } from "commander";
+import cliProgress from "cli-progress";
 import { createClient } from "../lib/client.js";
 import { validateHash } from "../lib/validate.js";
-import * as fs from "fs";
+import { formatTransaction } from "../formatters/transaction.js";
+import { InvalidInputError } from "../lib/errors.js";
+
+interface BatchResult {
+  hash: string;
+  status: "ok" | "error";
+  data?: unknown;
+  error?: string;
+}
+
+/** Read non-empty, non-comment lines from a file, one hash per line. */
+async function readHashes(filePath: string): Promise<string[]> {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new InvalidInputError(`File not found: ${resolved}`);
+  }
+  const rl = readline.createInterface({
+    input: fs.createReadStream(resolved),
+    crlfDelay: Infinity,
+  });
+  const hashes: string[] = [];
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (trimmed && !trimmed.startsWith("#")) hashes.push(trimmed);
+  }
+  if (hashes.length === 0) {
+    throw new InvalidInputError(`No hashes found in file: ${resolved}`);
+  }
+  return hashes;
+}
 
 export function registerBatch(program: Command): void {
   program
     .command("batch <file>")
-    .description("Explain multiple transaction hashes from a file")
-    .option("--dry-run", "Validate and list hashes without making API calls", false)
-    .action(async (file: string, cmdOpts: { dryRun: boolean }) => {
-      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
-      const hashes = fs.readFileSync(file, "utf8").split("\n").map(h => h.trim()).filter(Boolean);
+    .description("Explain multiple transaction hashes read from a file (one per line)")
+    .option("--output <path>", "Write results to a JSON file instead of stdout")
+    .option("--concurrency <n>", "Number of parallel requests", (v) => parseInt(v, 10), 3)
+    .action(async (file: string, cmdOpts: { output?: string; concurrency: number }) => {
+      const opts = program.opts<{
+        url: string;
+        timeout: number;
+        verbose: boolean;
+        json: boolean;
+      }>();
 
+      const hashes = await readHashes(file);
+      const client = createClient({
+        baseUrl: opts.url,
+        timeout: opts.timeout,
+        verbose: opts.verbose,
+      });
+
+      // Validate all hashes upfront so the user gets a clear error before any
+      // network calls are made.
       for (const hash of hashes) {
         validateHash(hash);
       }
 
-      if (cmdOpts.dryRun) {
-        process.stderr.write(`Dry run — ${hashes.length} hash(es) found, no API calls made:\n`);
-        for (const hash of hashes) {
-          process.stderr.write(`  ${hash}\n`);
+      const results: BatchResult[] = [];
+      const toOutput = Boolean(cmdOpts.output);
+
+      // Only show the progress bar when not piping to a file and not in
+      // --json mode, so stdout stays clean for downstream consumers.
+      const showBar = !toOutput && !opts.json;
+      const bar = showBar
+        ? new cliProgress.SingleBar(
+            {
+              format: "Processing [{bar}] {value}/{total} hashes | ETA: {eta}s",
+              clearOnComplete: true,
+            },
+            cliProgress.Presets.shades_classic,
+          )
+        : null;
+
+      bar?.start(hashes.length, 0);
+
+      // Process in chunks of `concurrency` to bound parallelism.
+      const concurrency = Math.max(1, cmdOpts.concurrency);
+      for (let i = 0; i < hashes.length; i += concurrency) {
+        const chunk = hashes.slice(i, i + concurrency);
+        const settled = await Promise.allSettled(
+          chunk.map((hash) => client.getTransaction(hash)),
+        );
+        for (let j = 0; j < chunk.length; j++) {
+          const hash = chunk[j]!;
+          const outcome = settled[j]!;
+          if (outcome.status === "fulfilled") {
+            results.push({ hash, status: "ok", data: outcome.value });
+          } else {
+            const msg =
+              outcome.reason instanceof Error
+                ? outcome.reason.message
+                : String(outcome.reason);
+            results.push({ hash, status: "error", error: msg });
+          }
+          bar?.increment();
         }
+      }
+
+      bar?.stop();
+
+      // --output: write JSON file
+      if (cmdOpts.output) {
+        const outPath = path.resolve(cmdOpts.output);
+        fs.writeFileSync(outPath, JSON.stringify(results, null, 2), "utf8");
+        process.stdout.write(`Wrote ${results.length} results to ${outPath}\n`);
         return;
       }
 
-      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
-      const results: unknown[] = [];
-      for (const hash of hashes) {
-        const tx = await client.getTransaction(hash);
-        results.push(tx);
+      // --json: raw JSON to stdout
+      if (opts.json) {
+        console.log(JSON.stringify(results, null, 2));
+        return;
       }
-      console.log(JSON.stringify(results, null, 2));
+
+      // Default: human-readable output
+      for (const result of results) {
+        process.stdout.write(`\n— ${result.hash}\n`);
+        if (result.status === "error") {
+          process.stderr.write(`  Error: ${result.error}\n`);
+        } else {
+          console.log(formatTransaction(result.data));
+        }
+      }
     });
 }

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -55,9 +55,12 @@ export function registerWatch(program: Command): void {
 
             // Normalise: the status field may sit at the top level or inside
             // a nested `result` object depending on the API version.
+            // Cast through unknown so TypeScript allows the index access on a
+            // typed struct without requiring an index signature on the type.
+            const txRecord = tx as unknown as Record<string, unknown>;
             const status: string | undefined =
-              (tx as Record<string, unknown>)["status"] as string | undefined ??
-              ((tx as Record<string, unknown>)["result"] as Record<string, unknown> | undefined)?.[
+              txRecord["status"] as string | undefined ??
+              (txRecord["result"] as Record<string, unknown> | undefined)?.[
                 "status"
               ] as string | undefined;
 

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -1,31 +1,95 @@
 import type { Command } from "commander";
 import { createClient } from "../lib/client.js";
 import { validateHash } from "../lib/validate.js";
+import { formatTransaction } from "../formatters/transaction.js";
+
+const DEFAULT_INTERVAL_MS = 4_000;
+const DEFAULT_TIMEOUT_MS  = 120_000;
 
 export function registerWatch(program: Command): void {
   program
     .command("watch <hash>")
-    .description("Poll a transaction hash until confirmed")
-    .option("--interval <ms>", "Polling interval in ms", (v) => parseInt(v, 10), 3000)
-    .option("--watch-timeout <ms>", "Stop polling after N ms", (v) => parseInt(v, 10), 60000)
-    .action(async (hash: string, cmdOpts: { interval: number; watchTimeout: number }) => {
-      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
-      validateHash(hash);
-      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+    .description("Poll a transaction until it reaches 'success' or 'failed' status")
+    .option(
+      "--interval <ms>",
+      "Polling interval in milliseconds",
+      (v) => parseInt(v, 10),
+      DEFAULT_INTERVAL_MS,
+    )
+    .option(
+      "--watch-timeout <ms>",
+      "Maximum total time to wait in milliseconds",
+      (v) => parseInt(v, 10),
+      DEFAULT_TIMEOUT_MS,
+    )
+    .action(
+      async (hash: string, cmdOpts: { interval: number; watchTimeout: number }) => {
+        const opts = program.opts<{
+          url: string;
+          timeout: number;
+          verbose: boolean;
+          json: boolean;
+        }>();
 
-      let cancelled = false;
-      process.on("SIGINT", () => {
-        cancelled = true;
-        process.stderr.write("\nWatch cancelled.\n");
-        process.exit(0);
-      });
+        validateHash(hash);
 
-      const deadline = Date.now() + cmdOpts.watchTimeout;
-      while (!cancelled && Date.now() < deadline) {
-        const tx = await client.getTransaction(hash);
-        if (opts.json) { console.log(JSON.stringify(tx, null, 2)); break; }
-        console.log(tx);
-        break;
-      }
-    });
+        const client = createClient({
+          baseUrl:  opts.url,
+          timeout:  opts.timeout,
+          verbose:  opts.verbose,
+        });
+
+        const intervalMs     = Math.max(500, cmdOpts.interval);
+        const watchTimeoutMs = Math.max(intervalMs * 2, cmdOpts.watchTimeout);
+        const deadline       = Date.now() + watchTimeoutMs;
+        let   attempt        = 0;
+
+        process.stderr.write(
+          `Watching ${hash} (interval ${intervalMs}ms, timeout ${watchTimeoutMs}ms)…\n`,
+        );
+
+        while (Date.now() < deadline) {
+          attempt++;
+          try {
+            const tx = await client.getTransaction(hash);
+
+            // Normalise: the status field may sit at the top level or inside
+            // a nested `result` object depending on the API version.
+            const status: string | undefined =
+              (tx as Record<string, unknown>)["status"] as string | undefined ??
+              ((tx as Record<string, unknown>)["result"] as Record<string, unknown> | undefined)?.[
+                "status"
+              ] as string | undefined;
+
+            const terminal = status === "success" || status === "failed";
+
+            if (!opts.json) {
+              process.stderr.write(
+                `  [${attempt}] status: ${status ?? "unknown"}${terminal ? " ✓" : ""}\n`,
+              );
+            }
+
+            if (terminal) {
+              console.log(opts.json ? JSON.stringify(tx, null, 2) : formatTransaction(tx));
+              return;
+            }
+          } catch (err) {
+            // Non-fatal: network hiccup or 404 while the tx propagates.
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(`  [${attempt}] fetch error: ${msg}\n`);
+          }
+
+          await sleep(intervalMs);
+        }
+
+        process.stderr.write(
+          `Error: timed out after ${watchTimeoutMs}ms waiting for ${hash}\n`,
+        );
+        process.exit(1);
+      },
+    );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { registerTx } from "./commands/tx.js";
 import { registerAccount } from "./commands/account.js";
 import { registerHealth } from "./commands/health.js";
 import { registerBatch } from "./commands/batch.js";
+import { registerWatch } from "./commands/watch.js";
 import { InvalidInputError } from "./lib/errors.js";
 
 // #99 — Node version check
@@ -22,7 +23,6 @@ const { version } = require("../package.json") as { version: string };
 runUpdateCheck(version);
 
 const program = new Command();
-
 program
   .name("stellar-explain")
   .version(version)
@@ -40,6 +40,7 @@ registerTx(program);
 registerAccount(program);
 registerHealth(program);
 registerBatch(program);
+registerWatch(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
### batch command
- `stellar-explain batch <file>` - reads hashes (one per line, `#` comments supported) and explains each one
- Progress bar via `cli-progress` (suppressed when piping or using `--json`)
- `--output <path>` writes all results to a JSON file
- `--concurrency <n>` controls parallel requests (default 3)
- Validates all hashes upfront; per-hash failures don't abort the run

### watch command
- `stellar-explain watch <hash>` - polls until status is `success` or `failed`
- `--interval <ms>` (default 4000) and `--watch-timeout <ms>` (default 120000)
- Network errors are retried, not fatal; exits 1 on timeout
- Progress to stderr so `--json` stdout stays pipeable

### changed files
- `src/commands/batch.ts` (new)
- `src/commands/watch.ts` (new)
- `src/index.ts` - registers `watch`
- `package.json` - adds `cli-progress` + `@types/cli-progress`

closes #429
closes #431
closes #432
closes #433