### PR TITLE
feat: Add .stellar-explain.json config file for persisting url and timeout defaults

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,4 +1,7 @@
+import { readConfigFile } from "./configFile";
+
 const DEFAULT_URL = "http://localhost:8080";
+const DEFAULT_TIMEOUT = 5000;
 
 function isLocalhost(url: string): boolean {
   try {
@@ -19,9 +22,15 @@ export function warnIfInsecure(url: string): void {
 }
 
 export function resolveBaseUrl(flagUrl?: string): string {
-  const url = flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? DEFAULT_URL;
+  const fileConfig = readConfigFile();
+  const url = flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? fileConfig.url ?? DEFAULT_URL;
   warnIfInsecure(url);
   return url;
+}
+
+export function resolveTimeout(flagTimeout?: number): number {
+  const fileConfig = readConfigFile();
+  return flagTimeout ?? fileConfig.timeout ?? DEFAULT_TIMEOUT;
 }
 
 export function validateUrl(url: string): string {
@@ -33,8 +42,11 @@ export function validateUrl(url: string): string {
   return url;
 }
 
-export function loadConfig(url?: string): { baseUrl: string } {
-  return { baseUrl: resolveBaseUrl(url) };
+export function loadConfig(url?: string): { baseUrl: string; timeout: number } {
+  return {
+    baseUrl: resolveBaseUrl(url),
+    timeout: resolveTimeout(),
+  };
 }
 
 export function buildUrl(base: string, path: string): string {

--- a/packages/cli/src/lib/configFile.ts
+++ b/packages/cli/src/lib/configFile.ts
@@ -1,0 +1,42 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+export interface ConfigFileData {
+  url?: string;
+  timeout?: number;
+}
+
+const CONFIG_FILE_NAME = ".stellar-explain.json";
+
+export function findConfigFile(): string | null {
+  const cwdPath = path.join(process.cwd(), CONFIG_FILE_NAME);
+  if (fs.existsSync(cwdPath)) {
+    return cwdPath;
+  }
+
+  const homePath = path.join(os.homedir(), CONFIG_FILE_NAME);
+  if (fs.existsSync(homePath)) {
+    return homePath;
+  }
+
+  return null;
+}
+
+export function readConfigFile(): ConfigFileData {
+  const configPath = findConfigFile();
+
+  if (!configPath) {
+    return {};
+  }
+
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    return JSON.parse(raw) as ConfigFileData;
+  } catch {
+    process.stderr.write(
+      `Warning: Could not parse config file at ${configPath}\n`
+    );
+    return {};
+  }
+}


### PR DESCRIPTION
Closes #430
Closes #434
Closes #435
Closes #436

## What this does
- Created `packages/cli/src/lib/configFile.ts` to read `.stellar-explain.json` from the current directory or home directory
- Updated `packages/cli/src/lib/config.ts` to use values from the config file as defaults for `url` and `timeout`