### PR TITLE
Align release workflow with the CLI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   release:
-    name: Release SDK
+    name: Release CLI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,43 +20,43 @@ jobs:
           # Full history is required so changesets can diff tags correctly.
           fetch-depth: 0
 
-      # Gate all subsequent steps on packages/sdk existing.
-      # The SDK package has not been scaffolded yet; this prevents the job
+      # Gate all subsequent steps on packages/cli existing.
+      # This prevents the job
       # from crashing with "No such file or directory" on every push to main.
-      # Once packages/sdk/package.json is added, all steps below will run.
-      - name: Check if SDK package exists
-        id: sdk-check
+      # Once packages/cli/package.json is present, all steps below will run.
+      - name: Check if CLI package exists
+        id: cli-check
         run: |
-          if [ -f packages/sdk/package.json ]; then
+          if [ -f packages/cli/package.json ]; then
             echo "exists=true" >> $GITHUB_OUTPUT
           else
-            echo "packages/sdk not found — skipping SDK release"
+            echo "packages/cli not found — skipping CLI release"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Setup Node
-        if: steps.sdk-check.outputs.exists == 'true'
+        if: steps.cli-check.outputs.exists == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install SDK dependencies
-        if: steps.sdk-check.outputs.exists == 'true'
+      - name: Install CLI dependencies
+        if: steps.cli-check.outputs.exists == 'true'
         run: npm ci
-        working-directory: packages/sdk
+        working-directory: packages/cli
 
-      - name: Build SDK
-        if: steps.sdk-check.outputs.exists == 'true'
+      - name: Build CLI
+        if: steps.cli-check.outputs.exists == 'true'
         run: npm run build
-        working-directory: packages/sdk
+        working-directory: packages/cli
 
       - name: Create Release PR or Publish to npm
-        if: steps.sdk-check.outputs.exists == 'true'
+        if: steps.cli-check.outputs.exists == 'true'
         uses: changesets/action@v1
         with:
           # Command that changesets/action calls when it decides to publish.
-          publish: npm run changeset:publish --prefix packages/sdk
+          publish: npm run changeset:publish --prefix packages/cli
           # Optional: customise the version-bump PR title / commit message.
           title: "chore: version packages"
           commit: "chore: version packages"


### PR DESCRIPTION
This PR updates the release workflow to target the actual `packages/cli` package instead of the stale `packages/sdk` path, keeping the release job runnable on main.

Closes #397, closes #398, closes #399, and closes #400.

Summary:
- renames the release job to CLI
- checks for `packages/cli/package.json`
- runs install/build/publish steps in `packages/cli`