### PR TITLE
CLI: retries knob for flaky networks

### DIFF
--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -8,9 +8,9 @@ export function registerAccount(program: Command): void {
     .command("account <address>")
     .description("Explain a Stellar account")
     .action(async (address: string) => {
-      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
+      const opts = program.opts<{ url: string; timeout: number; retries: number; verbose: boolean; json: boolean }>();
       validateAddress(address);
-      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, retries: opts.retries, verbose: opts.verbose });
       const acc = await client.getAccount(address);
       console.log(opts.json ? JSON.stringify(acc, null, 2) : formatAccount(acc));
     });

--- a/packages/cli/src/commands/health.ts
+++ b/packages/cli/src/commands/health.ts
@@ -6,8 +6,8 @@ export function registerHealth(program: Command): void {
     .command("health")
     .description("Check API health status")
     .action(async () => {
-      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
-      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const opts = program.opts<{ url: string; timeout: number; retries: number; verbose: boolean; json: boolean }>();
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, retries: opts.retries, verbose: opts.verbose });
       const h = await client.getHealth();
       if (opts.json) { console.log(JSON.stringify(h, null, 2)); return; }
       console.log(`Status:   ${h.status}`);

--- a/packages/cli/src/commands/tx.ts
+++ b/packages/cli/src/commands/tx.ts
@@ -8,9 +8,9 @@ export function registerTx(program: Command): void {
     .command("tx <hash>")
     .description("Explain a Stellar transaction")
     .action(async (hash: string) => {
-      const opts = program.opts<{ url: string; timeout: number; verbose: boolean; json: boolean }>();
+      const opts = program.opts<{ url: string; timeout: number; retries: number; verbose: boolean; json: boolean }>();
       validateHash(hash);
-      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, verbose: opts.verbose });
+      const client = createClient({ baseUrl: opts.url, timeout: opts.timeout, retries: opts.retries, verbose: opts.verbose });
       const tx = await client.getTransaction(hash);
       console.log(opts.json ? JSON.stringify(tx, null, 2) : formatTransaction(tx));
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -28,6 +28,7 @@ program
   .version(version)
   .option("--url <url>", "API base URL")
   .option("--timeout <ms>", "Request timeout in ms", (v) => parseInt(v, 10), 10000)
+  .option("--retries <n>", "Retry attempts for network errors", (v) => parseInt(v, 10), 2)
   .option("--verbose", "Log request details to stderr", false)
   .option("--json", "Output raw JSON", false);
 

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -9,9 +9,10 @@ export interface ClientOptions {
   baseUrl: string;
   timeout: number;  // #276
   verbose: boolean; // #277
+  retries: number; // #414
 }
 
-async function request<T>(
+async function requestOnce<T>(
   url: string,
   opts: ClientOptions,
 ): Promise<T> {
@@ -52,6 +53,22 @@ async function request<T>(
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function request<T>(url: string, opts: ClientOptions): Promise<T> {
+  const retries = Number.isFinite(opts.retries) && opts.retries >= 0 ? opts.retries : 0;
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await requestOnce<T>(url, opts);
+    } catch (err) {
+      lastError = err;
+      // Only retry transient network failures.
+      if (!(err instanceof NetworkError) || attempt >= retries) throw err;
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  throw lastError;
 }
 
 export function createClient(opts: ClientOptions) {


### PR DESCRIPTION
Adds a global `--retries` flag and wires it through the CLI client so transient network errors can be retried.

- `--retries <n>` defaults to 2
- Retries only on `NetworkError`

Closes #413
Closes #414
Closes #415
Closes #416
