### PR TITLE
fix(cli): add update-check opt-out

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { resolveBaseUrl } from "./lib/config.js";
+import { readConfigFile } from "./lib/configFile.js";
 import { runUpdateCheck } from "./lib/updateCheck.js";
 import { registerTx } from "./commands/tx.js";
 import { registerAccount } from "./commands/account.js";
@@ -13,7 +14,7 @@ import { EXIT_CODE } from "./lib/exitCodes.js";
 import { parseMs } from "./lib/parseMs.js";
 import { getCliVersion } from "./lib/pkgVersion.js";
 
-// #99 — Node version check
+// #99 - Node version check
 const [major = 0] = process.version.replace("v", "").split(".").map(Number);
 if (major < 18) {
   process.stderr.write(`Error: Node.js 18 or higher is required (found ${process.version}).\n`);
@@ -21,9 +22,12 @@ if (major < 18) {
 }
 
 const version = getCliVersion();
+const configFile = readConfigFile();
+const updateCheckEnabled =
+  configFile.updateCheck !== false && !process.argv.slice(2).includes("--no-update-check");
 
-// #100 — Non-blocking update check
-runUpdateCheck(version);
+// #100 - Non-blocking update check
+runUpdateCheck(version, updateCheckEnabled);
 
 const program = new Command();
 program
@@ -33,6 +37,7 @@ program
   .option("--timeout <ms>", "Request timeout in ms", (v) => parseInt(v, 10), 10000)
   .option("--retries <n>", "Retry attempts for network errors", (v) => parseInt(v, 10), 2)
   .option("--timeout <ms>", "Request timeout in ms", parseMs, 10000)
+  .option("--no-update-check", "Disable the startup CLI update notification", false)
   .option("--verbose", "Log request details to stderr", false)
   .option("--json", "Output raw JSON", false);
 

--- a/packages/cli/src/lib/configFile.ts
+++ b/packages/cli/src/lib/configFile.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 export interface ConfigFileData {
   url?: string;
   timeout?: number;
+  updateCheck?: boolean;
 }
 
 const CONFIG_FILE_NAME = ".stellar-explain.json";

--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -30,7 +30,9 @@ function isNewer(latest: string, current: string): boolean {
   return lPat > cPat;
 }
 
-export function runUpdateCheck(currentVersion: string): void {
+export function runUpdateCheck(currentVersion: string, enabled = true): void {
+  if (!enabled) return;
+
   fetchLatestVersion()
     .then((latest) => {
       if (isNewer(latest, currentVersion)) {
@@ -40,5 +42,5 @@ export function runUpdateCheck(currentVersion: string): void {
         );
       }
     })
-    .catch(() => { /* silently ignore — must not block or crash */ });
+    .catch(() => { /* silently ignore - must not block or crash */ });
 }


### PR DESCRIPTION
Closes #493.

## Summary
- Adds a global --no-update-check option for users who want to suppress startup update notifications.
- Adds .stellar-explain.json support for { "updateCheck": false }.
- Keeps the existing non-blocking default update check behavior unchanged.

## Validation
- Static review of the three touched CLI files.
- Verified the fork branch compares cleanly against upstream main with only the intended files changed.