### PR TITLE
fix(cli): handle non-JSON API error responses gracefully

### DIFF
--- a/packages/cli/src/commands/batch.ts
+++ b/packages/cli/src/commands/batch.ts
@@ -49,6 +49,7 @@ export function registerBatch(program: Command): void {
         timeout: number;
         verbose: boolean;
         json: boolean;
+        retries: number;
       }>();
 
       const hashes = await readHashes(file);
@@ -56,6 +57,7 @@ export function registerBatch(program: Command): void {
         baseUrl: opts.url,
         timeout: opts.timeout,
         verbose: opts.verbose,
+        retries: opts.retries ?? 0,
       });
 
       // Validate all hashes upfront so the user gets a clear error before any

--- a/packages/cli/src/commands/watch.ts
+++ b/packages/cli/src/commands/watch.ts
@@ -29,6 +29,7 @@ export function registerWatch(program: Command): void {
           timeout: number;
           verbose: boolean;
           json: boolean;
+          retries: number;
         }>();
 
         validateHash(hash);
@@ -37,6 +38,7 @@ export function registerWatch(program: Command): void {
           baseUrl:  opts.url,
           timeout:  opts.timeout,
           verbose:  opts.verbose,
+          retries:  opts.retries ?? 0,
         });
 
         const intervalMs     = Math.max(500, cmdOpts.interval);

--- a/packages/cli/src/formatters/transaction.ts
+++ b/packages/cli/src/formatters/transaction.ts
@@ -16,10 +16,8 @@ export function formatTransaction(tx: TransactionExplanation, useColor = false):
   if (tx.payments.length > 0) {
     lines.push("", "Payments:");
     const fromW = Math.max(...tx.payments.map((p) => p.from.length));
-    const toW   = Math.max(...tx.payments.map((p) => p.to.length));
-    const amtW  = Math.max(...tx.payments.map((p) => p.amount.length));
     for (const p of tx.payments) {
-      lines.push(`  ${p.from} → ${p.to}  ${colorize(p.amount, 32, useColor)} ${p.asset}`);
+      lines.push(`  ${p.from.padEnd(fromW)} → ${p.to}  ${colorize(p.amount, 32, useColor)} ${p.asset}`);
     }
   }
 

--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,4 +1,4 @@
-import { NetworkError, NotFoundError } from "./errors.js";
+import { NetworkError, NotFoundError, NonJsonResponseError } from "./errors.js";
 import type {
   TransactionExplanation,
   AccountExplanation,
@@ -33,7 +33,7 @@ async function requestOnce<T>(
       const contentType = res.headers.get("content-type") ?? "";
       if (!contentType.includes("application/json")) {
         const text = await res.text();
-        throw new NetworkError(`HTTP ${res.status}: non-JSON response — ${text.slice(0, 120)}`);
+        throw new NonJsonResponseError(res.status, text.slice(0, 120));
       }
       throw new NetworkError(`HTTP ${res.status}: ${url}`);
     }
@@ -41,12 +41,12 @@ async function requestOnce<T>(
     const contentType = res.headers.get("content-type") ?? "";
     if (!contentType.includes("application/json")) {
       const text = await res.text();
-      throw new NetworkError(`Expected JSON but got: ${text.slice(0, 120)}`);
+      throw new NonJsonResponseError(res.status, text.slice(0, 120));
     }
 
     return res.json() as Promise<T>;
   } catch (err) {
-    if (err instanceof NotFoundError || err instanceof NetworkError) throw err;
+    if (err instanceof NotFoundError || err instanceof NetworkError || err instanceof NonJsonResponseError) throw err;
     if ((err as Error).name === "AbortError")
       throw new NetworkError(`Request timed out after ${opts.timeout}ms`);
     throw new NetworkError(`Request failed: ${(err as Error).message}`);

--- a/packages/cli/src/lib/exitCodes.ts
+++ b/packages/cli/src/lib/exitCodes.ts
@@ -1,6 +1,9 @@
-export const EXIT_CODE = {
-  OK: 0,
-  ERROR: 1,
-  INVALID_INPUT: 2,
-} as const;
+export const EXIT_SUCCESS = 0;
+export const EXIT_API_ERROR = 1;
+export const EXIT_INPUT_ERROR = 2;
 
+export const EXIT_CODE = {
+  OK: EXIT_SUCCESS,
+  ERROR: EXIT_API_ERROR,
+  INVALID_INPUT: EXIT_INPUT_ERROR,
+} as const;

--- a/packages/cli/tests/client.test.ts
+++ b/packages/cli/tests/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createClient } from "../src/lib/client.js";
-import { NetworkError, NotFoundError } from "../src/lib/errors.js";
+import { NetworkError, NotFoundError, NonJsonResponseError } from "../src/lib/errors.js";
 
 const defaultOpts = {
   baseUrl: "http://localhost:4000",
@@ -184,6 +184,53 @@ describe("createClient", () => {
       expect(writeSpy).not.toHaveBeenCalled();
 
       writeSpy.mockRestore();
+    });
+  });
+
+  // ── Non-JSON responses ─────────────────────────────────────────
+
+  describe("non-JSON response", () => {
+    function mockNonJsonResponse(status: number, body: string, ok = false) {
+      return vi.fn(() =>
+        Promise.resolve({
+          status,
+          ok,
+          headers: { get: (_name: string) => "text/html" },
+          json: () => Promise.reject(new SyntaxError("Unexpected token")),
+          text: () => Promise.resolve(body),
+        }),
+      );
+    }
+
+    it("throws NonJsonResponseError when a 200 response has non-JSON content-type", async () => {
+      vi.stubGlobal("fetch", mockNonJsonResponse(200, "<html>Not found</html>", true));
+
+      const client = createClient(defaultOpts);
+
+      await expect(client.getTransaction("abc")).rejects.toThrow(NonJsonResponseError);
+      await expect(client.getTransaction("abc")).rejects.toThrow(
+        "HTTP 200: non-JSON response",
+      );
+    });
+
+    it("throws NonJsonResponseError when an error response has non-JSON content-type", async () => {
+      vi.stubGlobal("fetch", mockNonJsonResponse(503, "Service Unavailable", false));
+
+      const client = createClient(defaultOpts);
+
+      await expect(client.getHealth()).rejects.toThrow(NonJsonResponseError);
+      await expect(client.getHealth()).rejects.toThrow(
+        "HTTP 503: non-JSON response",
+      );
+    });
+
+    it("includes a preview of the response body in the error message", async () => {
+      const body = "Bad Gateway";
+      vi.stubGlobal("fetch", mockNonJsonResponse(502, body, false));
+
+      const client = createClient(defaultOpts);
+
+      await expect(client.getHealth()).rejects.toThrow(body);
     });
   });
 });


### PR DESCRIPTION
## Summary

Resolves #489

When the API returns a non-JSON body the CLI previously crashed with an unhandled `SyntaxError` from `JSON.parse`. This PR fixes that and also resolves the pre-existing test failures present on `main`.

## Changes

### Issue #489 — non-JSON response handling (`client.ts`, `errors.ts`)
- Throw `NonJsonResponseError` (already defined in `errors.ts` but unused) instead of `NetworkError` when the response `content-type` is not `application/json`, for both error-status and 2xx responses
- Add `NonJsonResponseError` to the inner `catch` re-throw guard so it reaches callers without being double-wrapped
- 3 new unit tests: 200 non-JSON body, 5xx non-JSON body, body preview in message

### Pre-existing test failures fixed
| File | Failure | Fix |
|------|---------|-----|
| `exitCodes.ts` | `EXIT_SUCCESS` / `EXIT_API_ERROR` / `EXIT_INPUT_ERROR` exported `undefined` | Added named `const` exports alongside the existing `EXIT_CODE` object |
| `formatters/transaction.ts` | Payment arrow column misaligned | Apply `padEnd(fromW)` to the `from` field |
| `commands/batch.ts` / `watch.ts` | TypeScript error: `retries` missing from `ClientOptions` | Add `retries` to `program.opts<>()" type and pass it to `createClient` |

## Test results

```
Test Files  11 passed | 1 skipped (12)
     Tests  84 passed | 3 skipped (87)
```

Lint ✅ · Typecheck ✅ · Build ✅