### PR TITLE
feat(widget): add embeddable Stellar Explain iframe widget for transactions and accounts

### DIFF
--- a/packages/ui/next.config.ts
+++ b/packages/ui/next.config.ts
@@ -1,8 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   output: "standalone",
+  async headers() {
+    return [
+      {
+        source: "/widget/:path*",
+        headers: [
+          { key: "X-Frame-Options", value: "ALLOWALL" },
+          { key: "Content-Security-Policy", value: "frame-ancestors *" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/packages/ui/public/widget.js
+++ b/packages/ui/public/widget.js
@@ -1,0 +1,73 @@
+(function () {
+  var BASE_URL = "https://stellar-explain.xyz";
+
+  function getScriptBase() {
+    var scripts = document.querySelectorAll("script[src]");
+    for (var i = 0; i < scripts.length; i++) {
+      var src = scripts[i].src;
+      if (src && src.indexOf("widget.js") !== -1) {
+        return src.replace(/\/widget\.js.*$/, "");
+      }
+    }
+    return BASE_URL;
+  }
+
+  function initWidget(el) {
+    var hash = el.getAttribute("data-hash");
+    var address = el.getAttribute("data-address");
+    var theme = el.getAttribute("data-theme") || "dark";
+
+    if (!hash && !address) return;
+
+    var base = getScriptBase();
+    var path = hash
+      ? "/widget/tx/" + encodeURIComponent(hash)
+      : "/widget/account/" + encodeURIComponent(address);
+    var src = base + path + (theme === "light" ? "?theme=light" : "");
+
+    var iframe = document.createElement("iframe");
+    iframe.src = src;
+    iframe.style.cssText = [
+      "border:none",
+      "width:100%",
+      "min-width:300px",
+      "max-width:600px",
+      "min-height:200px",
+      "display:block",
+      "border-radius:12px",
+      "overflow:hidden",
+    ].join(";");
+    iframe.setAttribute("loading", "lazy");
+    iframe.setAttribute("title", hash ? "Stellar Transaction" : "Stellar Account");
+    iframe.setAttribute("scrolling", "no");
+
+    // Auto-resize via postMessage (optional enhancement)
+    iframe.onload = function () {
+      try {
+        var doc = iframe.contentDocument || iframe.contentWindow.document;
+        if (doc && doc.body) {
+          iframe.style.minHeight = doc.body.scrollHeight + "px";
+        }
+      } catch (e) {
+        // cross-origin, use fallback height
+        iframe.style.minHeight = "320px";
+      }
+    };
+
+    el.style.display = "block";
+    el.appendChild(iframe);
+  }
+
+  function init() {
+    var widgets = document.querySelectorAll("#stellar-explain-widget, [data-stellar-widget]");
+    for (var i = 0; i < widgets.length; i++) {
+      initWidget(widgets[i]);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/packages/ui/src/app/widget/account/[address]/page.tsx
+++ b/packages/ui/src/app/widget/account/[address]/page.tsx
@@ -1,0 +1,236 @@
+import { fetchAccount, isApiError } from "@/lib/api";
+import { formatBalance } from "@/lib/utils";
+
+interface Props {
+  params: Promise<{ address: string }>;
+  searchParams: Promise<{ theme?: string }>;
+}
+
+function truncate(str: string, start = 8, end = 6) {
+  if (str.length <= start + end + 3) return str;
+  return `${str.slice(0, start)}…${str.slice(-end)}`;
+}
+
+export default async function WidgetAccountPage({ params, searchParams }: Props) {
+  const { address } = await params;
+  const { theme } = await searchParams;
+  const isLight = theme === "light";
+
+  const bg = isLight ? "#ffffff" : "#080c12";
+  const cardBg = isLight ? "#f4f5f7" : "#0f1520";
+  const border = isLight ? "#e2e5ea" : "rgba(255,255,255,0.07)";
+  const text = isLight ? "#111827" : "#e8eaf0";
+  const muted = isLight ? "#6b7280" : "rgba(255,255,255,0.45)";
+  const accent = "#38bdf8";
+
+  let data;
+  let errorMsg: string | null = null;
+
+  try {
+    data = await fetchAccount(address);
+  } catch (err) {
+    errorMsg = isApiError(err)
+      ? err.error.message
+      : "Failed to load account.";
+  }
+
+  if (errorMsg || !data) {
+    return (
+      <div
+        style={{
+          background: bg,
+          color: text,
+          fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+          padding: "20px",
+          minHeight: "120px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <p style={{ color: "#f87171", fontSize: "13px", margin: 0 }}>
+          ⚠ {errorMsg ?? "Unknown error"}
+        </p>
+        <a
+          href={`https://stellar-explain.xyz/account/${address}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: accent, fontSize: "12px", marginTop: "8px" }}
+        >
+          Try viewing on Stellar Explain →
+        </a>
+        <p style={{ color: muted, fontSize: "11px", marginTop: "12px" }}>
+          Powered by{" "}
+          <a
+            href="https://stellar-explain.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: accent }}
+          >
+            Stellar Explain
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        background: bg,
+        color: text,
+        fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+        padding: "16px",
+        fontSize: "13px",
+        lineHeight: "1.5",
+      }}
+    >
+      {/* Header */}
+      <div style={{ marginBottom: "12px" }}>
+        <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          Account
+        </p>
+        <p
+          style={{
+            fontFamily: "'IBM Plex Mono', monospace",
+            fontSize: "11px",
+            color: muted,
+            margin: 0,
+            wordBreak: "break-all",
+          }}
+        >
+          {truncate(data.address, 12, 8)}
+        </p>
+      </div>
+
+      {/* Summary */}
+      <div
+        style={{
+          background: cardBg,
+          border: `1px solid ${border}`,
+          borderRadius: "8px",
+          padding: "12px",
+          marginBottom: "10px",
+        }}
+      >
+        <p style={{ color: muted, fontSize: "10px", margin: "0 0 4px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          Summary
+        </p>
+        <p style={{ margin: 0, color: text, fontSize: "13px" }}>{data.summary}</p>
+      </div>
+
+      {/* Stats */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(3, 1fr)",
+          gap: "8px",
+          marginBottom: "10px",
+        }}
+      >
+        {[
+          { label: "XLM Balance", value: formatBalance(data.xlm_balance), sub: "XLM" },
+          { label: "Other Assets", value: String(data.asset_count), sub: "trust lines" },
+          { label: "Signers", value: String(data.signer_count), sub: "keys" },
+        ].map((stat) => (
+          <div
+            key={stat.label}
+            style={{
+              background: cardBg,
+              border: `1px solid ${border}`,
+              borderRadius: "8px",
+              padding: "10px",
+            }}
+          >
+            <p style={{ color: muted, fontSize: "10px", margin: "0 0 4px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+              {stat.label}
+            </p>
+            <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "15px", color: text, margin: "0 0 2px" }}>
+              {stat.value}
+            </p>
+            <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "10px", color: muted, margin: 0 }}>
+              {stat.sub}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Home domain */}
+      {data.home_domain && (
+        <div
+          style={{
+            background: cardBg,
+            border: `1px solid ${border}`,
+            borderRadius: "8px",
+            padding: "12px",
+            marginBottom: "10px",
+          }}
+        >
+          <p style={{ color: muted, fontSize: "10px", margin: "0 0 4px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Home Domain
+          </p>
+          <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "12px", color: muted, margin: 0 }}>
+            {data.home_domain}
+          </p>
+        </div>
+      )}
+
+      {/* Flags */}
+      {data.flag_descriptions.length > 0 && (
+        <div
+          style={{
+            background: cardBg,
+            border: `1px solid ${border}`,
+            borderRadius: "8px",
+            padding: "12px",
+            marginBottom: "10px",
+          }}
+        >
+          <p style={{ color: muted, fontSize: "10px", margin: "0 0 8px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Account Flags
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: "6px" }}>
+            {data.flag_descriptions.map((flag, i) => (
+              <span
+                key={i}
+                style={{
+                  background: "rgba(251,191,36,0.12)",
+                  color: "#fbbf24",
+                  border: "1px solid rgba(251,191,36,0.25)",
+                  borderRadius: "4px",
+                  padding: "2px 8px",
+                  fontSize: "11px",
+                }}
+              >
+                {flag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "12px" }}>
+        <a
+          href={`https://stellar-explain.xyz/account/${data.address}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: accent, fontSize: "12px", textDecoration: "none" }}
+        >
+          View full explanation →
+        </a>
+        <p style={{ color: muted, fontSize: "11px", margin: 0 }}>
+          Powered by{" "}
+          <a
+            href="https://stellar-explain.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: accent, textDecoration: "none" }}
+          >
+            Stellar Explain
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/app/widget/layout.tsx
+++ b/packages/ui/src/app/widget/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
+import "../../../app/globals.css";
+
+const ibmPlexMono = IBM_Plex_Mono({
+  variable: "--font-mono",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+});
+
+const ibmPlexSans = IBM_Plex_Sans({
+  variable: "--font-sans",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+});
+
+export const metadata: Metadata = {
+  title: "Stellar Explain Widget",
+};
+
+export default function WidgetLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body
+        className={`${ibmPlexMono.variable} ${ibmPlexSans.variable} antialiased`}
+        suppressHydrationWarning
+      >
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/packages/ui/src/app/widget/tx/[hash]/page.tsx
+++ b/packages/ui/src/app/widget/tx/[hash]/page.tsx
@@ -1,0 +1,258 @@
+import { fetchTransaction } from "@/lib/api";
+import { isApiError } from "@/lib/api";
+import { formatLedgerTime } from "@/lib/utils";
+
+interface Props {
+  params: Promise<{ hash: string }>;
+  searchParams: Promise<{ theme?: string }>;
+}
+
+function truncate(str: string, start = 8, end = 6) {
+  if (str.length <= start + end + 3) return str;
+  return `${str.slice(0, start)}…${str.slice(-end)}`;
+}
+
+export default async function WidgetTxPage({ params, searchParams }: Props) {
+  const { hash } = await params;
+  const { theme } = await searchParams;
+  const isLight = theme === "light";
+
+  const bg = isLight ? "#ffffff" : "#080c12";
+  const cardBg = isLight ? "#f4f5f7" : "#0f1520";
+  const border = isLight ? "#e2e5ea" : "rgba(255,255,255,0.07)";
+  const text = isLight ? "#111827" : "#e8eaf0";
+  const muted = isLight ? "#6b7280" : "rgba(255,255,255,0.45)";
+  const accent = "#38bdf8";
+
+  let data;
+  let errorMsg: string | null = null;
+
+  try {
+    data = await fetchTransaction(hash);
+  } catch (err) {
+    errorMsg = isApiError(err)
+      ? err.error.message
+      : "Failed to load transaction.";
+  }
+
+  if (errorMsg || !data) {
+    return (
+      <div
+        style={{
+          background: bg,
+          color: text,
+          fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+          padding: "20px",
+          minHeight: "120px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+        }}
+      >
+        <p style={{ color: "#f87171", fontSize: "13px", margin: 0 }}>
+          ⚠ {errorMsg ?? "Unknown error"}
+        </p>
+        <a
+          href={`https://stellar-explain.xyz/tx/${hash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: accent, fontSize: "12px", marginTop: "8px" }}
+        >
+          Try viewing on Stellar Explain →
+        </a>
+        <p style={{ color: muted, fontSize: "11px", marginTop: "12px" }}>
+          Powered by{" "}
+          <a
+            href="https://stellar-explain.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: accent }}
+          >
+            Stellar Explain
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        background: bg,
+        color: text,
+        fontFamily: "'IBM Plex Sans', system-ui, sans-serif",
+        padding: "16px",
+        fontSize: "13px",
+        lineHeight: "1.5",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+          marginBottom: "12px",
+          gap: "8px",
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Transaction
+          </p>
+          <p
+            style={{
+              fontFamily: "'IBM Plex Mono', monospace",
+              fontSize: "11px",
+              color: muted,
+              margin: 0,
+              wordBreak: "break-all",
+            }}
+          >
+            {truncate(data.transaction_hash)}
+          </p>
+        </div>
+        <span
+          style={{
+            background: data.successful ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)",
+            color: data.successful ? "#4ade80" : "#f87171",
+            border: `1px solid ${data.successful ? "rgba(34,197,94,0.3)" : "rgba(239,68,68,0.3)"}`,
+            borderRadius: "4px",
+            padding: "2px 8px",
+            fontSize: "11px",
+            fontWeight: 500,
+            whiteSpace: "nowrap",
+          }}
+        >
+          {data.successful ? "Confirmed" : "Failed"}
+        </span>
+      </div>
+
+      {/* Summary */}
+      <div
+        style={{
+          background: cardBg,
+          border: `1px solid ${border}`,
+          borderRadius: "8px",
+          padding: "12px",
+          marginBottom: "10px",
+        }}
+      >
+        <p style={{ color: muted, fontSize: "10px", margin: "0 0 4px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+          Summary
+        </p>
+        <p style={{ margin: 0, color: text, fontSize: "13px" }}>{data.summary}</p>
+      </div>
+
+      {/* Timeline */}
+      {(data.ledger_closed_at || data.ledger) && (
+        <div
+          style={{
+            background: cardBg,
+            border: `1px solid ${border}`,
+            borderRadius: "8px",
+            padding: "12px",
+            marginBottom: "10px",
+            display: "flex",
+            gap: "24px",
+            flexWrap: "wrap",
+          }}
+        >
+          {data.ledger_closed_at && (
+            <div>
+              <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Confirmed at
+              </p>
+              <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "12px", color: muted, margin: 0 }}>
+                {formatLedgerTime(data.ledger_closed_at)}
+              </p>
+            </div>
+          )}
+          {data.ledger && (
+            <div>
+              <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                Ledger
+              </p>
+              <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "12px", color: muted, margin: 0 }}>
+                #{data.ledger.toLocaleString()}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Payments */}
+      {data.payment_explanations.length > 0 && (
+        <div
+          style={{
+            background: cardBg,
+            border: `1px solid ${border}`,
+            borderRadius: "8px",
+            padding: "12px",
+            marginBottom: "10px",
+          }}
+        >
+          <p style={{ color: muted, fontSize: "10px", margin: "0 0 8px", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+            Payments ({data.payment_explanations.length})
+          </p>
+          {data.payment_explanations.slice(0, 3).map((p, i) => (
+            <div
+              key={i}
+              style={{
+                borderTop: i > 0 ? `1px solid ${border}` : "none",
+                paddingTop: i > 0 ? "8px" : 0,
+                marginTop: i > 0 ? "8px" : 0,
+                display: "flex",
+                gap: "12px",
+                flexWrap: "wrap",
+              }}
+            >
+              <div>
+                <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px" }}>From</p>
+                <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "11px", color: muted, margin: 0 }}>
+                  {truncate(p.from)}
+                </p>
+              </div>
+              <div>
+                <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px" }}>To</p>
+                <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "11px", color: muted, margin: 0 }}>
+                  {truncate(p.to)}
+                </p>
+              </div>
+              <div>
+                <p style={{ color: muted, fontSize: "10px", margin: "0 0 2px" }}>Amount</p>
+                <p style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: "11px", color: muted, margin: 0 }}>
+                  {p.amount} <span style={{ color: isLight ? "#9ca3af" : "rgba(255,255,255,0.3)" }}>{p.asset}</span>
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Footer */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: "12px" }}>
+        <a
+          href={`https://stellar-explain.xyz/tx/${data.transaction_hash}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: accent, fontSize: "12px", textDecoration: "none" }}
+        >
+          View full explanation →
+        </a>
+        <p style={{ color: muted, fontSize: "11px", margin: 0 }}>
+          Powered by{" "}
+          <a
+            href="https://stellar-explain.xyz"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ color: accent, textDecoration: "none" }}
+          >
+            Stellar Explain
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
closes #514

## Summary

Adds a lightweight embeddable Stellar Explain widget that can be integrated into any website with a single script tag.

## Changes

- Added `widget.js` script for iframe-based widget embedding
- Added widget routes for transaction and account explanations
- Created minimal widget layout without global navigation
- Added cross-origin iframe support for `/widget/*` routes
- Implemented dark theme by default with light theme override support
- Added responsive sizing and error states for invalid resources
- Added "View full explanation" links to full Stellar Explain pages

## Supported Embeds

```html
<div id="stellar-explain-widget" data-hash="TX_HASH"></div>
<script src="/widget.js" async></script>
```

## Testing

- [x] Verified transaction and account widgets render correctly
- [x] Verified iframe style isolation from host page CSS
- [x] Verified cross-origin loading works
- [x] Verified responsive behavior and theme overrides
- [x] TypeScript compiles without errors