### PR TITLE
cli: add completion command and shell install docs

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,53 @@ CLI tool for the Stellar Explain API.
 npx @stellar-explain/cli <command>
 ```
 
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `tx <hash>` | Explain a transaction |
+| `account <address>` | Explain an account |
+| `health` | Check API health |
+| `batch` | Explain multiple items |
+| `watch` | Watch for updates |
+| `history` | View command history |
+| `version` | Print version |
+| `config` | Manage configuration |
+| `completion <shell>` | Output shell completion script |
+
+## Shell Completion
+
+Enable tab completion for `stellar-explain` commands in your shell.
+
+### Bash
+
+```sh
+stellar-explain completion bash >> ~/.bash_completion
+source ~/.bash_completion
+```
+
+To persist across sessions, add the `source` line to your `~/.bashrc`:
+
+```sh
+echo 'source ~/.bash_completion' >> ~/.bashrc
+```
+
+### Zsh
+
+```sh
+stellar-explain completion zsh > "${fpath[1]}/_stellar-explain"
+exec zsh
+```
+
+> Make sure `~/.zfunc` or another directory is in your `$fpath`. If needed:
+> ```sh
+> mkdir -p ~/.zfunc
+> stellar-explain completion zsh > ~/.zfunc/_stellar-explain
+> echo 'fpath=(~/.zfunc $fpath)' >> ~/.zshrc
+> echo 'autoload -Uz compinit && compinit' >> ~/.zshrc
+> exec zsh
+> ```
+
 ## Development
 
 ```sh

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { generateCompletion, type Shell } from "../lib/completion.js";
+
+export function registerCompletion(program: Command): void {
+  program
+    .command("completion <shell>")
+    .description("Output shell completion script (bash or zsh)")
+    .action((shell: string) => {
+      if (shell !== "bash" && shell !== "zsh") {
+        process.stderr.write(`Error: unsupported shell "${shell}". Use bash or zsh.\n`);
+        process.exit(1);
+      }
+      console.log(generateCompletion(shell as Shell));
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { registerAccount } from "./commands/account.js";
 import { registerHealth } from "./commands/health.js";
 import { registerBatch } from "./commands/batch.js";
 import { registerWatch } from "./commands/watch.js";
+import { registerCompletion } from "./commands/completion.js";
 import { InvalidInputError } from "./lib/errors.js";
 import { BIN_NAME } from "./lib/binName.js";
 import { EXIT_CODE } from "./lib/exitCodes.js";
@@ -46,6 +47,7 @@ registerAccount(program);
 registerHealth(program);
 registerBatch(program);
 registerWatch(program);
+registerCompletion(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Closes #486

Adds the `completion` command to the CLI and documents bash/zsh shell completion install instructions in `packages/cli/README.md`.

## Changes

- **`src/commands/completion.ts`** — new `completion <shell>` command that outputs the bash or zsh completion script via `generateCompletion()` from the existing `lib/completion.ts`
- **`src/index.ts`** — registers the completion command
- **`README.md`** — adds a Shell Completion section with step-by-step install instructions for bash and zsh

## Testing

- `npx tsc --noEmit` passes with no errors