### PR TITLE
fix: warn on insecure base URLs

### DIFF
--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -23,7 +23,7 @@ function isLocalhost(url: string): boolean {
 export function warnIfInsecure(url: string): void {
   if (url.startsWith("http://") && !isLocalhost(url)) {
     process.stderr.write(
-      `Warning: STELLAR_EXPLAIN_URL is set to a non-HTTPS URL (${url}). ` +
+      `Warning: base URL is set to a non-HTTPS URL (${url}). ` +
       `Data will be transmitted over an insecure connection.\n`
     );
   }
@@ -31,9 +31,7 @@ export function warnIfInsecure(url: string): void {
 
 export function resolveBaseUrl(flagUrl?: string): string {
   const fileConfig = readConfigFile();
-  const url = flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? fileConfig.url ?? DEFAULT_URL;
-  warnIfInsecure(url);
-  return url;
+  return flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? fileConfig.url ?? DEFAULT_URL;
 }
 
 export function resolveTimeout(flagTimeout?: number): number {
@@ -51,8 +49,10 @@ export function validateUrl(url: string): string {
 }
 
 export function loadConfig(url?: string): { baseUrl: string; timeout: number } {
+  const baseUrl = resolveBaseUrl(url);
+  warnIfInsecure(baseUrl);
   return {
-    baseUrl: resolveBaseUrl(url),
+    baseUrl,
     timeout: resolveTimeout(),
   };
 }

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { resolveBaseUrl } from "../src/lib/config.js";
+import { loadConfig, resolveBaseUrl } from "../src/lib/config.js";
 
 const DEFAULT = "http://localhost:8080";
 
@@ -25,5 +25,30 @@ describe("resolveBaseUrl", () => {
   it("prefers flag over env var", () => {
     vi.stubEnv("STELLAR_EXPLAIN_URL", "https://env.example.com");
     expect(resolveBaseUrl("https://flag.example.com")).toBe("https://flag.example.com");
+  });
+});
+
+describe("loadConfig", () => {
+  it("warns once for insecure non-localhost HTTP base URLs", () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.stubEnv("STELLAR_EXPLAIN_URL", "http://example.com");
+
+    expect(loadConfig()).toEqual({ baseUrl: "http://example.com", timeout: 5000 });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Warning: base URL is set to a non-HTTPS URL (http://example.com)."),
+    );
+
+    writeSpy.mockRestore();
+  });
+
+  it("does not warn for localhost HTTP base URLs", () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.stubEnv("STELLAR_EXPLAIN_URL", "http://localhost:3000");
+
+    expect(loadConfig()).toEqual({ baseUrl: "http://localhost:3000", timeout: 5000 });
+    expect(writeSpy).not.toHaveBeenCalled();
+
+    writeSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Make base URL resolution pure and emit the insecure-HTTP warning after the final URL is known
- Update the warning text to refer to the base URL instead of the env var source
- Add tests for the insecure HTTP warning and localhost exception

## Validation
- `npm test -- --run tests/config.test.ts`
- `npm run build`
- `npm test`

Closes #491