### PR TITLE
feat: make CLI update check non-blocking

### DIFF
--- a/packages/cli/src/lib/updateCheck.ts
+++ b/packages/cli/src/lib/updateCheck.ts
@@ -5,7 +5,7 @@ const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
 
 function fetchLatestVersion(): Promise<string> {
   return new Promise((resolve, reject) => {
-    https.get(REGISTRY_URL, (res) => {
+    const request = https.get(REGISTRY_URL, (res) => {
       let data = "";
       res.on("data", (chunk: string) => { data += chunk; });
       res.on("end", () => {
@@ -17,7 +17,12 @@ function fetchLatestVersion(): Promise<string> {
           reject(e);
         }
       });
-    }).on("error", reject);
+    });
+
+    request.on("socket", (socket) => {
+      socket.unref();
+    });
+    request.on("error", reject);
   });
 }
 

--- a/packages/cli/tests/updateCheck.test.ts
+++ b/packages/cli/tests/updateCheck.test.ts
@@ -1,0 +1,66 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const httpsGetMock = vi.hoisted(() => vi.fn());
+vi.mock("https", () => ({
+  get: httpsGetMock,
+}));
+
+import { runUpdateCheck } from "../src/lib/updateCheck.js";
+
+afterEach(() => {
+  httpsGetMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+function waitForNextTick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("runUpdateCheck", () => {
+  it("prints a notice when a newer version is available", async () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const socket = { unref: vi.fn() };
+
+    httpsGetMock.mockImplementation(((...args: any[]) => {
+      const callback = args[1] as (res: EventEmitter) => void;
+      const request = new EventEmitter();
+      const response = new EventEmitter();
+
+      callback(response);
+
+      queueMicrotask(() => {
+        request.emit("socket", socket);
+        response.emit("data", JSON.stringify({ version: "9.9.9" }));
+        response.emit("end");
+      });
+
+      return request as any;
+    }) as any);
+
+    runUpdateCheck("1.0.0");
+    await waitForNextTick();
+
+    expect(socket.unref).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Notice: A newer version of @stellar-explain/cli is available (9.9.9)."),
+    );
+  });
+
+  it("silently ignores registry errors", async () => {
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    httpsGetMock.mockImplementation(((...args: any[]) => {
+      const request = new EventEmitter();
+      queueMicrotask(() => {
+        request.emit("error", new Error("registry unavailable"));
+      });
+      return request as any;
+    }) as any);
+
+    runUpdateCheck("1.0.0");
+    await waitForNextTick();
+
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Keep the startup update check asynchronous without holding the CLI process open
- Unref the HTTPS socket used to query the npm registry
- Add tests for the update notice path and registry failure handling

## Validation
- `npm test -- --run tests/updateCheck.test.ts`
- `npm run build`
- `npm test`

Closes #492