### PR TITLE
feat: add config get/list subcommands and format.ts re-export

### DIFF
--- a/packages/cli/src/commands/configGet.ts
+++ b/packages/cli/src/commands/configGet.ts
@@ -2,12 +2,15 @@ import type { Command } from "commander";
 import { loadLocalConfig } from "../lib/localConfig.js";
 
 export function registerConfigGet(program: Command): void {
-  program
-    .command("config-get <key>")
+  const config =
+    program.commands.find((c) => c.name() === "config") ??
+    program.command("config").description("Manage local CLI configuration");
+  config
+    .command("get <key>")
     .description("Read a config value from .stellar-explain.json")
     .action((key: string) => {
-      const config = loadLocalConfig() as Record<string, unknown>;
-      const val = config[key];
+      const data = loadLocalConfig() as Record<string, unknown>;
+      const val = data[key];
       if (val === undefined) {
         process.stderr.write(`Key not found: ${key}\n`);
         process.exit(1);

--- a/packages/cli/src/commands/configList.ts
+++ b/packages/cli/src/commands/configList.ts
@@ -2,16 +2,19 @@ import type { Command } from "commander";
 import { loadLocalConfig } from "../lib/localConfig.js";
 
 export function registerConfigList(program: Command): void {
-  program
-    .command("config-list")
+  const config =
+    program.commands.find((c) => c.name() === "config") ??
+    program.command("config").description("Manage local CLI configuration");
+  config
+    .command("list")
     .description("Print all current config values")
     .action(() => {
-      const config = loadLocalConfig();
-      if (Object.keys(config).length === 0) {
+      const data = loadLocalConfig();
+      if (Object.keys(data).length === 0) {
         console.log("No config set.");
         return;
       }
-      for (const [k, v] of Object.entries(config)) {
+      for (const [k, v] of Object.entries(data)) {
         console.log(`${k}=${v}`);
       }
     });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ import { registerExplain } from "./commands/explain.js";
 import { registerWatch } from "./commands/watch.js";
 import { registerCompletion } from "./commands/completion.js";
 import { registerConfigSet } from "./commands/configSet.js";
+import { registerConfigGet } from "./commands/configGet.js";
+import { registerConfigList } from "./commands/configList.js";
 import { BIN_NAME } from "./lib/binName.js";
 import { EXIT_CODE } from "./lib/exitCodes.js";
 import { parseMs } from "./lib/parseMs.js";
@@ -58,6 +60,8 @@ registerExplain(program);
 registerWatch(program);
 registerCompletion(program);
 registerConfigSet(program);
+registerConfigGet(program);
+registerConfigList(program);
 
 program.parseAsync(process.argv).catch((err: unknown) => {
   const msg = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -1,0 +1,1 @@
+export { truncateAddress } from "./truncate.js";


### PR DESCRIPTION
Implements:
- Closes #425: Create `format.ts` with `truncateAddress` helper (re-exports from truncate.ts)
- Closes #438: Add `config get` subcommand
- Closes #439: Add `config list` subcommand
- Closes #460: History tests (already present)