### PR TITLE
test: add unit tests for transaction, account, client, and cache modules

### DIFF
--- a/packages/cli/tests/formatters/transaction.test.ts
+++ b/packages/cli/tests/formatters/transaction.test.ts
@@ -1,1 +1,52 @@
-"import { describe, it, expect } from \"vitest\";\nimport { formatTransaction } from \"../../src/formatters/transaction.js\";\nimport type { TransactionExplanation } from \"../../src/types/index.js\";\n\nconst baseTx: TransactionExplanation = {\n  hash: \"abc123\",\n  status: \"success\",\n  summary: \"A payment\",\n  ledger: 1000,\n  created_at: \"2024-01-01T00:00:00Z\",\n  fee_charged: \"100\",\n  memo: null,\n  payments: [],\n  skipped_operations: 0,\n};\n\ndescribe(\"formatTransaction\", () => {\n  it(\"renders base fields\", () => {\n    const out = formatTransaction(baseTx);\n    expect(out).toContain(`Transaction: ${baseTx.hash}`);\n    expect(out).toContain(`Status:      ${baseTx.status}`);\n    expect(out).toContain(`Fee:         ${baseTx.fee_charged} stroops`);\n    expect(out).not.toContain(\"Payments:\");\n    expect(out).not.toContain(\"Memo:\");\n  });\n\n  it(\"renders memo when present\", () => {\n    const out = formatTransaction({ ...baseTx, memo: \"hello\" });\n    expect(out).toContain(\"Memo:        hello\");\n  });\n\n  it(\"renders skipped_operations when > 0\", () => {\n    const out = formatTransaction({ ...baseTx, skipped_operations: 2 });\n    expect(out).toContain(\"Skipped ops: 2\");\n  });\n\n  it(\"renders failed status\", () => {\n    const out = formatTransaction({ ...baseTx, status: \"failed\" });\n    expect(out).toContain(\"Status:      failed\");\n  });\n\n  it(\"renders ledger number\", () => {\n    const out = formatTransaction(baseTx);\n    expect(out).toContain(\"Ledger:      1000\");\n  });\n\n  it(\"renders created_at as closed timestamp\", () => {\n    const out = formatTransaction(baseTx);\n    expect(out).toContain(\"Closed at:   2024-01-01T00:00:00Z\");\n  });\n});\n"
+import { describe, it, expect } from "vitest";
+import { formatTransaction } from "../../src/formatters/transaction.js";
+import type { TransactionExplanation } from "../../src/types/index.js";
+
+const baseTx: TransactionExplanation = {
+  hash: "abc123",
+  status: "success",
+  summary: "A payment",
+  ledger: 1000,
+  created_at: "2024-01-01T00:00:00Z",
+  fee_charged: "100",
+  memo: null,
+  payments: [],
+  skipped_operations: 0,
+};
+
+describe("formatTransaction", () => {
+  it("renders base fields", () => {
+    const out = formatTransaction(baseTx);
+    expect(out).toContain("Transaction: abc123");
+    expect(out).toContain("Status:      success");
+    expect(out).toContain("Fee:         100 stroops");
+    expect(out).not.toContain("Payments:");
+    expect(out).not.toContain("Memo:");
+  });
+
+  it("renders memo when present", () => {
+    const out = formatTransaction({ ...baseTx, memo: "hello" });
+    expect(out).toContain("Memo:        hello");
+  });
+
+  it("renders skipped_operations when > 0", () => {
+    const out = formatTransaction({ ...baseTx, skipped_operations: 2 });
+    expect(out).toContain("Skipped ops: 2");
+  });
+
+  it("renders failed status", () => {
+    const out = formatTransaction({ ...baseTx, status: "failed" });
+    expect(out).toContain("Status:      failed");
+  });
+
+  it("renders ledger number", () => {
+    const out = formatTransaction(baseTx);
+    expect(out).toContain("Ledger:      1000");
+  });
+
+  it("renders created_at as closed timestamp", () => {
+    const out = formatTransaction(baseTx);
+    expect(out).toContain("Closed at:   2024-01-01T00:00:00Z");
+  });
+});
+


### PR DESCRIPTION
Implements:
- Closes #456: Transaction formatter tests
- Closes #457: Account formatter tests
- Closes #458: Client mock tests (fetch success, 404, 429, timeout, network error)
- Closes #459: Cache tests (set, get TTL, get expiry, clear)