### PR TITLE
feat(cli): support STELLAR_EXPLAIN_URL fallback

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,9 +30,16 @@ You can create a `.stellar-explain.json` file in your project directory (or home
 
 **Lookup order:**
 1. `--url` / `--timeout` CLI flags (highest priority)
-2. `.stellar-explain.json` in the current working directory
-3. `.stellar-explain.json` in the home directory (`~/`)
-4. Built-in defaults (`https://stellar-explain-core.onrender.com`, 10 000 ms)
+2. `STELLAR_EXPLAIN_URL` environment variable for the API base URL
+3. `.stellar-explain.json` in the current working directory
+4. `.stellar-explain.json` in the home directory (`~/`)
+5. Built-in defaults (`https://stellar-explain-core.onrender.com`, 10 000 ms)
+
+**Environment variable example:**
+
+```sh
+STELLAR_EXPLAIN_URL=http://localhost:3000 stellar-explain explain <transaction-or-account>
+```
 
 You can also manage the config file via the CLI:
 

--- a/packages/cli/src/config/env.ts
+++ b/packages/cli/src/config/env.ts
@@ -1,0 +1,10 @@
+export const STELLAR_EXPLAIN_URL_ENV = "STELLAR_EXPLAIN_URL";
+
+export function getEnvBaseUrl(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const value = env[STELLAR_EXPLAIN_URL_ENV]?.trim();
+  return value || undefined;
+}
+
+export function resolveBaseUrlInput(flagUrl?: string, fileUrl?: string): string | undefined {
+  return flagUrl ?? getEnvBaseUrl() ?? fileUrl;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,7 +8,7 @@ import { registerHealth } from "./commands/health.js";
 import { registerBatch } from "./commands/batch.js";
 import { registerExplain } from "./commands/explain.js";
 import { registerWatch } from "./commands/watch.js";
-import { registerCompletion } from "./commands/completion.js";
+import { registerCompletionCommand } from "./commands/completion.js";
 import { registerConfigSet } from "./commands/configSet.js";
 import { registerConfigGet } from "./commands/configGet.js";
 import { registerConfigList } from "./commands/configList.js";
@@ -17,38 +17,12 @@ import { EXIT_CODE } from "./lib/exitCodes.js";
 import { parseMs } from "./lib/parseMs.js";
 import { readConfigFile } from "./lib/configFile.js";
 import { getCliVersion } from "./lib/pkgVersion.js";
+import { resolveBaseUrlInput } from "./config/env.js";
 
 const program = new Command();
+const version = getCliVersion();
 
 program
-  .name('stellar-explain')
-  .description('CLI for exploring and explaining Stellar transactions and accounts')
-  .version('0.1.0');
-
-// ── Existing commands (stubs shown; replace with real implementations) ────────
-
-program
-  .command('tx <hash>')
-  .description('Look up and explain a Stellar transaction')
-  .action((hash: string) => {
-    addEntry('tx', hash);
-    // TODO: delegate to tx command handler
-    console.log(`Looking up transaction: ${hash}`);
-  });
-
-program
-  .command('account <id>')
-  .description('Look up and explain a Stellar account')
-  .action((id: string) => {
-    addEntry('account', id);
-    // TODO: delegate to account command handler
-    console.log(`Looking up account: ${id}`);
-  });
-
-registerHistoryCommand(program);    // #441 / #442 / #443
-registerCompletionCommand(program); // #440
-
-program.parse(process.argv);
   .name(BIN_NAME)
   .version(version)
   .option("--url <url>", "API base URL")
@@ -64,7 +38,7 @@ program.parse(process.argv);
 program.hook("preAction", (thisCommand) => {
   const opts = thisCommand.opts<{ url?: string; network?: string; updateCheck?: boolean }>();
   const fileConfig = readConfigFile();
-  const rawUrl = opts.url ?? fileConfig.url;
+  const rawUrl = resolveBaseUrlInput(opts.url, fileConfig.url);
   thisCommand.setOptionValue("url", resolveNetworkUrl(opts.network as any, rawUrl));
   runUpdateCheck(version, shouldRunUpdateCheck(opts.updateCheck, fileConfig.updateCheck));
 });
@@ -75,7 +49,7 @@ registerHealth(program);
 registerBatch(program);
 registerExplain(program);
 registerWatch(program);
-registerCompletion(program);
+registerCompletionCommand(program);
 registerConfigSet(program);
 registerConfigGet(program);
 registerConfigList(program);

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { readConfigFile } from "./configFile";
+import { resolveBaseUrlInput } from "../config/env";
 
 const DEFAULT_URL = "http://localhost:8080";
 const DEFAULT_TIMEOUT = 5000;
@@ -31,7 +32,7 @@ export function warnIfInsecure(url: string): void {
 
 export function resolveBaseUrl(flagUrl?: string): string {
   const fileConfig = readConfigFile();
-  return flagUrl ?? process.env["STELLAR_EXPLAIN_URL"] ?? fileConfig.url ?? DEFAULT_URL;
+  return resolveBaseUrlInput(flagUrl, fileConfig.url) ?? DEFAULT_URL;
 }
 
 export function resolveTimeout(flagTimeout?: number): number {

--- a/packages/cli/tests/config.test.ts
+++ b/packages/cli/tests/config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import { getEnvBaseUrl, resolveBaseUrlInput } from "../src/config/env.js";
 import { loadConfig, resolveBaseUrl } from "../src/lib/config.js";
 
 const DEFAULT = "http://localhost:8080";
@@ -25,6 +26,27 @@ describe("resolveBaseUrl", () => {
   it("prefers flag over env var", () => {
     vi.stubEnv("STELLAR_EXPLAIN_URL", "https://env.example.com");
     expect(resolveBaseUrl("https://flag.example.com")).toBe("https://flag.example.com");
+  });
+});
+
+describe("environment base URL", () => {
+  it("trims STELLAR_EXPLAIN_URL and ignores empty values", () => {
+    expect(getEnvBaseUrl({ STELLAR_EXPLAIN_URL: "  https://env.example.com  " })).toBe(
+      "https://env.example.com",
+    );
+    expect(getEnvBaseUrl({ STELLAR_EXPLAIN_URL: "   " })).toBeUndefined();
+  });
+
+  it("resolves base URL priority as flag, env, then config file", () => {
+    vi.stubEnv("STELLAR_EXPLAIN_URL", "https://env.example.com");
+
+    expect(resolveBaseUrlInput("https://flag.example.com", "https://file.example.com")).toBe(
+      "https://flag.example.com",
+    );
+    expect(resolveBaseUrlInput(undefined, "https://file.example.com")).toBe("https://env.example.com");
+
+    vi.unstubAllEnvs();
+    expect(resolveBaseUrlInput(undefined, "https://file.example.com")).toBe("https://file.example.com");
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a small environment config helper for `STELLAR_EXPLAIN_URL`.
- Applies URL precedence in the CLI entrypoint as `--url` > `STELLAR_EXPLAIN_URL` > config file > network default.
- Reuses the helper in existing config resolution and documents the env var in the CLI README.
- Removes stale stub code in `src/index.ts` so the CLI entrypoint typechecks/builds again.

## Validation
- PASS: `npm test -- --run tests/config.test.ts`
- PASS: `npm run typecheck`
- PASS: `npm run build`
- NOTE: `npm test` has pre-existing empty test-suite failures in `tests/configFile.test.ts`, `tests/validate.test.ts`, and `tests/formatters/health.test.ts`; 83 existing tests pass and 3 are skipped.

Closes #562