### PR TITLE
feat: throw ConnectionRefusedError when ECONNREFUSED is detected

### DIFF
--- a/packages/cli/src/lib/client.ts
+++ b/packages/cli/src/lib/client.ts
@@ -1,4 +1,4 @@
-import { NetworkError, NotFoundError, NonJsonResponseError } from "./errors.js";
+import { NetworkError, NotFoundError, NonJsonResponseError, ConnectionRefusedError } from "./errors.js";
 import type {
   TransactionExplanation,
   AccountExplanation,
@@ -49,6 +49,10 @@ async function requestOnce<T>(
     if (err instanceof NotFoundError || err instanceof NetworkError || err instanceof NonJsonResponseError) throw err;
     if ((err as Error).name === "AbortError")
       throw new NetworkError(`Request timed out after ${opts.timeout}ms`);
+    // Detect ECONNREFUSED from the underlying fetch error cause
+    const cause = (err as { cause?: { message?: string } }).cause;
+    if (cause?.message?.includes("ECONNREFUSED"))
+      throw new ConnectionRefusedError(url);
     throw new NetworkError(`Request failed: ${(err as Error).message}`);
   } finally {
     clearTimeout(timer);

--- a/packages/cli/src/lib/errors.ts
+++ b/packages/cli/src/lib/errors.ts
@@ -22,3 +22,11 @@ export class NonJsonResponseError extends Error {
     this.name = "NonJsonResponseError";
   }
 }
+
+export class ConnectionRefusedError extends Error {
+  readonly exitCode = EXIT_CODE.ERROR;
+  constructor(url: string) {
+    super(`Connection refused at ${url}. Is the Stellar Explain backend running?`);
+    this.name = "ConnectionRefusedError";
+  }
+}

--- a/packages/cli/tests/client.test.ts
+++ b/packages/cli/tests/client.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createClient } from "../src/lib/client.js";
-import { NetworkError, NotFoundError, NonJsonResponseError } from "../src/lib/errors.js";
+import { NetworkError, NotFoundError, NonJsonResponseError, ConnectionRefusedError } from "../src/lib/errors.js";
 
 const defaultOpts = {
   baseUrl: "http://localhost:4000",
   timeout: 5000,
   verbose: false,
+  retries: 0,
 };
 
 function mockFetchResponse(status: number, body: unknown) {
@@ -154,6 +155,38 @@ describe("createClient", () => {
 
       await expect(client.getHealth()).rejects.toThrow(NetworkError);
       await expect(client.getHealth()).rejects.toThrow("Request failed: Failed to fetch");
+    });
+  });
+
+  // ── ECONNREFUSED ──────────────────────────────────────────────
+
+  describe("connection refused", () => {
+    it("throws ConnectionRefusedError when fetch rejects with ECONNREFUSED cause", async () => {
+      const cause = new Error("connect ECONNREFUSED 127.0.0.1:4000");
+      const fetchError = new TypeError("fetch failed");
+      Object.assign(fetchError, { cause });
+
+      vi.stubGlobal("fetch", vi.fn(() => Promise.reject(fetchError)));
+
+      const client = createClient(defaultOpts);
+
+      await expect(client.getHealth()).rejects.toThrow(ConnectionRefusedError);
+      await expect(client.getHealth()).rejects.toThrow(
+        "Connection refused at http://localhost:4000/health. Is the Stellar Explain backend running?",
+      );
+    });
+
+    it("falls through to NetworkError when cause does not contain ECONNREFUSED", async () => {
+      const cause = new Error("connect ENOTFOUND example.com");
+      const fetchError = new TypeError("fetch failed");
+      Object.assign(fetchError, { cause });
+
+      vi.stubGlobal("fetch", vi.fn(() => Promise.reject(fetchError)));
+
+      const client = createClient(defaultOpts);
+
+      await expect(client.getHealth()).rejects.toThrow(NetworkError);
+      await expect(client.getHealth()).rejects.toThrow("Request failed: fetch failed");
     });
   });
 


### PR DESCRIPTION
## Summary

When the Stellar Explain backend is down or unreachable, Node.js fetch throws a `TypeError` with `cause.message` containing "ECONNREFUSED". Previously this was caught by the generic `NetworkError` fallback, giving users a confusing "Request failed: fetch failed" message with no hint about the root cause.

This PR adds a specific `ConnectionRefusedError` that clearly tells users:

> Connection refused at http://... Is the Stellar Explain backend running?

## Changes

- **`errors.ts`**: New `ConnectionRefusedError` class with `EXIT_CODE.ERROR`
- **`client.ts`**: Detect `ECONNREFUSED` in `cause.message` before falling through to generic `NetworkError`
- **`client.test.ts`**: 2 new tests:
  - `ECONNREFUSED` → `ConnectionRefusedError` ✓
  - `ENOTFOUND` → `NetworkError` fallthrough ✓

## Test Results

```
✓ packages/cli/tests/client.test.ts (14 tests) 27ms
  Test Files  1 passed (1)
       Tests  14 passed (14)
```