### PR TITLE
Analytics #5 — Implement EventEmitter for analytics event queue

### DIFF
--- a/packages/analytics/src/emitter/EventEmitter.ts
+++ b/packages/analytics/src/emitter/EventEmitter.ts
@@ -1,0 +1,64 @@
+import { AnalyticsEvent, EventName } from "../types/events";
+
+export type EventHandler = (event: AnalyticsEvent) => void;
+
+export class EventEmitter {
+  private queue: AnalyticsEvent[] = [];
+  private handlers: Map<EventName, EventHandler[]> = new Map();
+  private draining = false;
+
+  on(eventName: EventName, handler: EventHandler): void {
+    const existing = this.handlers.get(eventName) ?? [];
+    existing.push(handler);
+    this.handlers.set(eventName, existing);
+  }
+
+  off(eventName: EventName, handler: EventHandler): void {
+    const existing = this.handlers.get(eventName);
+    if (!existing) return;
+    const filtered = existing.filter((h) => h !== handler);
+    if (filtered.length === 0) {
+      this.handlers.delete(eventName);
+    } else {
+      this.handlers.set(eventName, filtered);
+    }
+  }
+
+  track(event: AnalyticsEvent): void {
+    if (!EventName.includes(event.name)) {
+      console.warn(`Analytics: dropped unknown event "${event.name}"`);
+      return;
+    }
+    this.queue.push(event);
+    if (!this.draining) {
+      this.draining = true;
+      this.flush();
+    }
+  }
+
+  flush(): void {
+    while (this.queue.length > 0) {
+      const event = this.queue.shift()!;
+      const handlers = this.handlers.get(event.name) ?? [];
+      for (const handler of handlers) {
+        try {
+          handler(event);
+        } catch (err) {
+          console.error(
+            `Analytics: handler error for "${event.name}"`,
+            err,
+          );
+        }
+      }
+    }
+    this.draining = false;
+  }
+
+  queueSize(): number {
+    return this.queue.length;
+  }
+
+  clear(): void {
+    this.queue = [];
+  }
+}

--- a/packages/analytics/src/emitter/index.ts
+++ b/packages/analytics/src/emitter/index.ts
@@ -1,0 +1,2 @@
+export { EventEmitter } from "./EventEmitter";
+export type { EventHandler } from "./EventEmitter";

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+export { AnalyticsEvent, EventName } from "./types";
+export { EventEmitter } from "./emitter";
+export type { EventHandler } from "./emitter";

--- a/packages/analytics/src/types/events.ts
+++ b/packages/analytics/src/types/events.ts
@@ -1,0 +1,23 @@
+export const EventName = [
+  "page_view",
+  "button_click",
+  "form_submit",
+  "api_call",
+  "error_occurred",
+  "login",
+  "logout",
+  "search",
+  "purchase",
+  "refund",
+] as const;
+
+export type EventName = (typeof EventName)[number];
+
+export interface AnalyticsEvent {
+  id: string;
+  name: EventName;
+  timestamp: Date;
+  properties?: Record<string, unknown>;
+  userId?: string;
+  sessionId?: string;
+}

--- a/packages/analytics/src/types/index.ts
+++ b/packages/analytics/src/types/index.ts
@@ -1,0 +1,2 @@
+export { AnalyticsEvent, EventName } from "./events";
+export type { EventName as EventNameType } from "./events";


### PR DESCRIPTION
## Task\n\nCreate `src/emitter/EventEmitter.ts` — the core class for accepting, validating, and queuing analytics events.\n\n### Requirements\n- `track(event: AnalyticsEvent): void` — enqueues a validated event\n- Internal queue: `AnalyticsEvent[]`\n- Validates that `event.name` is a known event name; drops and logs unknown events\n- Emits events synchronously to registered handlers via `on()` / `off()`\n- Thread-safe queue drain via `flush()`\n- `queueSize()` and `clear()` helpers\n\nAlso includes the `AnalyticsEvent` type dependency (from #686).\n\nCloses #687