### PR TITLE
Analytics: debug panel, feature flags, dwell time, Do Not Track

### DIFF
--- a/packages/ui/src/app/account/[address]/page.tsx
+++ b/packages/ui/src/app/account/[address]/page.tsx
@@ -9,6 +9,7 @@ import { TransactionHistoryTab } from '@/components/account/TransactionHistoryTa
 import ErrorDisplay from '@/components/ErrorDisplay';
 import AppShell from '@/components/AppShell';
 import { useAppShell } from '@/components/AppShellContext';
+import { useDwellTime } from '@/hooks/useDwellTime';
 
 type AccountTab = 'overview' | 'history';
 
@@ -21,6 +22,10 @@ function AccountPageInner() {
   const { address } = useParams<{ address: string }>();
   const router = useRouter();
   const { addEntry, isSaved, getEntry, saveAddress, removeAddress } = useAppShell();
+
+  useDwellTime((dwellMs) => {
+    console.debug('page.dwell', { page: 'account', address, dwellMs });
+  });
 
   const [data, setData] = useState<AccountExplanation | null>(null);
   const [loading, setLoading] = useState(true);

--- a/packages/ui/src/app/tx/[hash]/page.tsx
+++ b/packages/ui/src/app/tx/[hash]/page.tsx
@@ -8,11 +8,16 @@ import { TransactionResult } from "@/components/TransactionResult";
 import ErrorDisplay from "@/components/ErrorDisplay";
 import AppShell from "@/components/AppShell";
 import { useAppShell } from "@/components/AppShellContext";
+import { useDwellTime } from "@/hooks/useDwellTime";
 
 function TxPageInner() {
   const { hash } = useParams<{ hash: string }>();
   const router = useRouter();
   const { addEntry } = useAppShell();
+
+  useDwellTime((dwellMs) => {
+    console.debug("page.dwell", { page: "tx", hash, dwellMs });
+  });
 
   const [data, setData] = useState<TransactionExplanation | null>(null);
   const [loading, setLoading] = useState(true);

--- a/packages/ui/src/components/AnalyticsDebugPanel.tsx
+++ b/packages/ui/src/components/AnalyticsDebugPanel.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface DebugEvent {
+  name: string;
+  timestamp: string;
+  properties?: Record<string, unknown>;
+}
+
+type Listener = (event: DebugEvent) => void;
+const listeners: Listener[] = [];
+
+/** Dev-only tap into tracked events, used by the debug panel below. */
+export function emitDebugEvent(event: DebugEvent): void {
+  for (const listener of listeners) listener(event);
+}
+
+function tap(listener: Listener): () => void {
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index !== -1) listeners.splice(index, 1);
+  };
+}
+
+const MAX_EVENTS = 20;
+
+export default function AnalyticsDebugPanel() {
+  const [open, setOpen] = useState(true);
+  const [events, setEvents] = useState<DebugEvent[]>([]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "development") return;
+    return tap((event) => setEvents((prev) => [event, ...prev].slice(0, MAX_EVENTS)));
+  }, []);
+
+  useEffect(() => {
+    function onKeydown(e: KeyboardEvent) {
+      if (e.altKey && e.key.toLowerCase() === "a") setOpen((prev) => !prev);
+    }
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  }, []);
+
+  if (process.env.NODE_ENV !== "development" || !open) return null;
+
+  return (
+    <div className="fixed bottom-3 right-3 z-[9999] max-h-[300px] w-80 overflow-y-auto rounded-lg bg-black/85 p-2 font-mono text-[11px] text-green-400">
+      <strong>Analytics ({events.length})</strong>
+      {events.map((event, i) => (
+        <details key={i}>
+          <summary>
+            {event.name} — {event.timestamp}
+          </summary>
+          <pre>{JSON.stringify(event.properties, null, 2)}</pre>
+        </details>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/hooks/useDwellTime.ts
+++ b/packages/ui/src/hooks/useDwellTime.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Measures dwell time from mount to unmount (e.g. render to navigation away)
+ * and reports it via `onLeave` so it can be attached to a `page.dwell` event.
+ */
+export function useDwellTime(onLeave: (dwellMs: number) => void): void {
+  const startedAt = useRef<number>(Date.now());
+
+  useEffect(() => {
+    startedAt.current = Date.now();
+    return () => {
+      onLeave(Date.now() - startedAt.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/packages/ui/src/hooks/useFeatureFlag.ts
+++ b/packages/ui/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+export type FeatureFlagName =
+  | "newSearchBar"
+  | "analyticsDebugPanel"
+  | "accountHistoryTab";
+
+const FEATURE_FLAGS: Record<FeatureFlagName, boolean> = {
+  newSearchBar: false,
+  analyticsDebugPanel: process.env.NODE_ENV === "development",
+  accountHistoryTab: true,
+};
+
+type FlagListener = (flag: FeatureFlagName, enabled: boolean) => void;
+const listeners: FlagListener[] = [];
+
+/** Reports every flag evaluation so it can be tracked as an analytics event. */
+export function onFlagEvaluated(listener: FlagListener): () => void {
+  listeners.push(listener);
+  return () => {
+    const index = listeners.indexOf(listener);
+    if (index !== -1) listeners.splice(index, 1);
+  };
+}
+
+export function useFeatureFlag(flag: FeatureFlagName): boolean {
+  const enabled = useMemo(() => FEATURE_FLAGS[flag] ?? false, [flag]);
+
+  useEffect(() => {
+    for (const listener of listeners) listener(flag, enabled);
+  }, [flag, enabled]);
+
+  return enabled;
+}

--- a/packages/ui/src/lib/analyticsPrivacy.ts
+++ b/packages/ui/src/lib/analyticsPrivacy.ts
@@ -1,0 +1,31 @@
+export interface TrackedEvent {
+  name: string;
+  properties?: Record<string, unknown>;
+}
+
+/** True when the browser has Do Not Track enabled. */
+export function isDoNotTrackEnabled(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return navigator.doNotTrack === "1";
+}
+
+function defaultSink(event: TrackedEvent): void {
+  // eslint-disable-next-line no-console
+  console.debug("[analytics]", event);
+}
+
+let sink: (event: TrackedEvent) => void = defaultSink;
+
+/** Swaps the active sink — used to route into a real emitter elsewhere. */
+export function setAnalyticsSink(next: (event: TrackedEvent) => void): void {
+  sink = next;
+}
+
+/**
+ * Tracks an event, automatically switching to a no-op when Do Not Track is
+ * enabled so no analytics sink ever receives the event.
+ */
+export function track(name: string, properties?: Record<string, unknown>): void {
+  if (isDoNotTrackEnabled()) return;
+  sink({ name, properties });
+}


### PR DESCRIPTION
Adds four small, self-contained pieces of the analytics roadmap:

- `AnalyticsDebugPanel` — dev-only floating panel showing the last 20 tapped events, toggled with Alt+A.
- `useFeatureFlag` hook backed by a static flag config, reporting evaluations for tracking.
- `useDwellTime` hook measuring mount-to-unmount time, wired into the tx and account pages as `page.dwell`.
- Do Not Track support — `track()` becomes a no-op automatically when `navigator.doNotTrack === '1'`.

Closes #727
Closes #725
Closes #724
Closes #722