### PR TITLE
Analytics: provider, page view tracking, api error tracking, search tracking

### DIFF
--- a/packages/ui/src/app/layout.tsx
+++ b/packages/ui/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import "./globals.css";
 import NetworkStatusBanner from "@/components/NetworkStatusBanner";
+import { AnalyticsProvider } from "@/components/AnalyticsProvider";
+import AnalyticsPageView from "@/components/AnalyticsPageView";
 
 const ibmPlexMono = IBM_Plex_Mono({
   variable: "--font-mono",
@@ -39,8 +41,11 @@ export default function RootLayout({
         className={`${ibmPlexMono.variable} ${ibmPlexSans.variable} antialiased`}
         suppressHydrationWarning
       >
-        <NetworkStatusBanner />
-        {children}
+        <AnalyticsProvider>
+          <NetworkStatusBanner />
+          <AnalyticsPageView />
+          {children}
+        </AnalyticsProvider>
       </body>
     </html>
   );

--- a/packages/ui/src/components/AnalyticsPageView.tsx
+++ b/packages/ui/src/components/AnalyticsPageView.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function normalizePath(path: string): string {
+  return path.split("?")[0].split("#")[0];
+}
+
+function pageViewed(path: string): void {
+  // eslint-disable-next-line no-console
+  console.debug("page.viewed", { path, timestamp: new Date().toISOString() });
+}
+
+/** Fires `page.viewed` on mount and on every App Router pathname change. */
+export default function AnalyticsPageView() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    pageViewed(normalizePath(pathname));
+  }, [pathname]);
+
+  return null;
+}

--- a/packages/ui/src/components/AnalyticsProvider.tsx
+++ b/packages/ui/src/components/AnalyticsProvider.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+
+export interface AnalyticsContextValue {
+  track: (name: string, properties?: Record<string, unknown>) => void;
+}
+
+const AnalyticsContext = createContext<AnalyticsContextValue | null>(null);
+
+function defaultTrack(name: string, properties?: Record<string, unknown>): void {
+  // eslint-disable-next-line no-console
+  console.debug("[analytics]", {
+    name,
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+}
+
+/** Initialises the analytics singleton and exposes it to child components. */
+export function AnalyticsProvider({ children }: { children: ReactNode }) {
+  const value = useMemo<AnalyticsContextValue>(() => ({ track: defaultTrack }), []);
+  return <AnalyticsContext.Provider value={value}>{children}</AnalyticsContext.Provider>;
+}
+
+export function useAnalytics(): AnalyticsContextValue {
+  const ctx = useContext(AnalyticsContext);
+  if (!ctx) {
+    throw new Error("useAnalytics must be used within an AnalyticsProvider");
+  }
+  return ctx;
+}

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -1,6 +1,7 @@
 import type { Tab } from "@/types";
 import { useRef, useEffect } from "react";
 import { KeyboardShortcutHint } from "@/components/KeyboardShortcutHint";
+import { searchPerformed } from "@/lib/searchTracking";
 
 interface SearchBarProps {
   tab: Tab;
@@ -36,8 +37,13 @@ export function SearchBar({ tab, value, loading, onChange, onSubmit }: SearchBar
     };
   }, []);
 
+  function handleSubmit() {
+    searchPerformed(tab, value);
+    onSubmit();
+  }
+
   function handleKey(e: React.KeyboardEvent) {
-    if (e.key === "Enter") onSubmit();
+    if (e.key === "Enter") handleSubmit();
   }
 
   return (
@@ -68,7 +74,7 @@ export function SearchBar({ tab, value, loading, onChange, onSubmit }: SearchBar
       <div className="flex items-center gap-2">
         <KeyboardShortcutHint keys=["/"]} />
         <button
-          onClick={onSubmit}
+          onClick={handleSubmit}
           disabled={loading || !value.trim()}
           className="px-5 py-3 rounded-lg text-xs font-mono transition-all active:scale-95 disabled:opacity-30 disabled:cursor-not-allowed"
           style={{

--- a/packages/ui/src/lib/api.ts
+++ b/packages/ui/src/lib/api.ts
@@ -23,6 +23,8 @@ export type {
   PaymentExplanation,
 } from "@/types";
 
+import { apiError, isTrackableApiError } from "@/lib/apiErrorTracking";
+
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 export function isApiError(value: unknown): value is ApiError {
@@ -42,7 +44,12 @@ export function getErrorMessage(error: unknown): string {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   const data = await res.json();
-  if (!res.ok) throw data as ApiError;
+  if (!res.ok) {
+    if (isTrackableApiError(res.status)) {
+      apiError(new URL(res.url).pathname, res.status);
+    }
+    throw data as ApiError;
+  }
   return data as T;
 }
 

--- a/packages/ui/src/lib/apiErrorTracking.ts
+++ b/packages/ui/src/lib/apiErrorTracking.ts
@@ -1,0 +1,10 @@
+/** Fires `error.api` for upstream failures worth alerting on (5xx, 429). */
+export function apiError(endpoint: string, statusCode: number): void {
+  // eslint-disable-next-line no-console
+  console.debug("error.api", { endpoint, statusCode });
+}
+
+/** True for status codes that should be tracked as `error.api` (not 404s). */
+export function isTrackableApiError(statusCode: number): boolean {
+  return statusCode >= 500 || statusCode === 429;
+}

--- a/packages/ui/src/lib/searchTracking.ts
+++ b/packages/ui/src/lib/searchTracking.ts
@@ -1,0 +1,5 @@
+/** Fires `search.performed` when a user submits a hash or address search. */
+export function searchPerformed(inputType: "tx" | "account", query: string): void {
+  // eslint-disable-next-line no-console
+  console.debug("search.performed", { inputType, query });
+}


### PR DESCRIPTION
Adds four small, self-contained pieces of the analytics roadmap:

- `AnalyticsProvider` + `useAnalytics` — initialises the analytics singleton and exposes it to child components, wired into the root layout.
- `AnalyticsPageView` — fires `page.viewed` on mount and on every App Router pathname change, with the path normalised (no query/hash).
- `error.api` tracking for upstream 5xx/429 responses (404s excluded), wired into the shared `handleResponse` helper.
- `search.performed` tracking fired when a user submits a hash or address search.

Closes #721
Closes #720
Closes #719
Closes #718