### PR TITLE
CLI documentation: man page generation and Next.js CI integration guide

### DIFF
--- a/packages/cli/docs/nextjs-integration.md
+++ b/packages/cli/docs/nextjs-integration.md
@@ -1,0 +1,117 @@
+# Using @stellar-explain/cli in a Next.js CI Pipeline
+
+This guide explains how to integrate the Stellar Explain CLI into a Next.js project's CI/CD pipeline to validate Stellar transactions during deployment.
+
+## Overview
+
+By running `stellar-explain` in your CI pipeline, you can:
+
+- Validate that transactions are explainable before deploying
+- Catch malformed or unexpected transaction data early
+- Generate deployment reports with transaction summaries
+- Ensure backend compatibility during upgrades
+
+## Prerequisites
+
+- A Next.js project (App Router or Pages Router)
+- Node.js 18+ installed in your CI environment
+- Access to the Stellar Explain backend (default: `https://stellar-explain-core.onrender.com`)
+
+## Installation
+
+Add the CLI as a dev dependency:
+
+```bash
+npm install --save-dev @stellar-explain/cli
+```
+
+## CI Integration Examples
+
+### GitHub Actions
+
+Create `.github/workflows/stellar-validate.yml`:
+
+```yaml
+name: Validate Stellar Transactions
+
+on:
+  pull_request:
+    paths:
+      - 'stellar/**/*.json'
+      - 'data/transactions/**'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Validate transaction files
+        run: |
+          for tx in data/transactions/*.json; do
+            hash=$(jq -r '.hash' "$tx")
+            echo "Validating $hash..."
+            npx stellar-explain tx "$hash" --no-update-check || exit 1
+          done
+```
+
+### GitLab CI
+
+Add to `.gitlab-ci.yml`:
+
+```yaml
+stellar-validate:
+  stage: test
+  image: node:20
+  script:
+    - npm ci
+    - |
+      for tx in data/transactions/*.json; do
+        hash=$(jq -r '.hash' "$tx")
+        echo "Validating $hash..."
+        npx stellar-explain tx "$hash" --no-update-check || exit 1
+      done
+  only:
+    changes:
+      - stellar/**/*.json
+```
+
+## Batch Validation
+
+For projects with many transactions, use the batch command:
+
+```bash
+# Create a batch file: stellar/batch.json
+# [
+#   {"type": "tx", "identifier": "hash1..."},
+#   {"type": "tx", "identifier": "hash2..."}
+# ]
+
+npx stellar-explain batch stellar/batch.json
+```
+
+## Using in Next.js Scripts
+
+Add to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "validate:stellar": "stellar-explain batch data/transactions/batch.json",
+    "ci:check": "npm run build && npm run validate:stellar"
+  }
+}
+```
+
+## Error Handling
+
+The CLI exits with code `1` on API errors and `2` on input errors. Use these codes in your pipeline to fail the build when transactions cannot be explained.
+
+## Caching
+
+The CLI caches responses locally. In CI, the cache directory (`~/.stellar-explain/`) is ephemeral, so each run fetches fresh data. Use the `--no-update-check` flag to suppress update notices.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,8 @@
   },
   "files": [
     "dist",
-    "bin"
+    "bin",
+    "man"
   ],
   "scripts": {
     "build": "tsc",
@@ -16,6 +17,7 @@
     "test": "vitest run",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
+    "generate:man": "bash scripts/generate-man.sh",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "npm run build && changeset publish",

--- a/packages/cli/scripts/generate-man.sh
+++ b/packages/cli/scripts/generate-man.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT="${1:-packages/cli/man/stellar-explain.1}"
+CLI_BIN="${2:-node packages/cli/bin/stellar-explain}"
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+if command -v help2man &>/dev/null; then
+  help2man \
+    --name "Query the Stellar Explain backend from your terminal" \
+    --section 1 \
+    --help-option "--help" \
+    --version-option "--version" \
+    --no-info \
+    "$CLI_BIN" > "$OUTPUT"
+  echo "Generated man page using help2man: $OUTPUT"
+else
+  cat > "$OUTPUT" << 'MANEOF'
+.TH STELLAR-EXPLAIN 1 "2026-07-29" "@stellar-explain/cli 0.1.0" "User Commands"
+.SH NAME
+stellar-explain \- Query the Stellar Explain backend from your terminal
+.SH SYNOPSIS
+.B stellar-explain
+[\fI\,--url <url>\/\fR] [\fI\,--no-update-check\/\fR] \fI\,<command>\/\fR [\fI\,<args>\/\fR]
+.SH DESCRIPTION
+Stellar Explain transforms raw Stellar Horizon data into clear, human-readable
+explanations. The CLI lets you query the backend from your terminal.
+.SH COMMANDS
+.TP
+.B tx <hash>
+Explain a transaction by its hash.
+.TP
+.B account <address>
+Explain an account by its public address.
+.TP
+.B health
+Check the backend API health.
+.TP
+.B batch <file>
+Process a batch of lookups from a JSON file.
+.TP
+.B cache clear
+Clear the local response cache.
+.TP
+.B version
+Show CLI and API versions.
+.SH OPTIONS
+.TP
+.B \-\-url <url>
+Backend URL (default: https://stellar-explain-core.onrender.com).
+.TP
+.B \-\-no-update-check
+Disable the background update check.
+.TP
+.B \-\-help
+Display this help and exit.
+.TP
+.B \-\-version
+Output version information and exit.
+.SH EXIT CODES
+.TP
+0
+Success.
+.TP
+1
+API or network error.
+.TP
+2
+Invalid input or configuration error.
+.SH ENVIRONMENT
+.TP
+.B NO_UPDATE_CHECK
+Set to 1 to disable the background update check.
+.SH CACHE
+Response data is cached in ~/.stellar-explain/. Cache TTLs are 5 minutes for
+transaction lookups and 60 seconds for account lookups.
+.SH BUGS
+Report bugs at https://github.com/StellarCommons/Stellar-Explain/issues
+.SH COPYRIGHT
+MIT License. See https://github.com/StellarCommons/Stellar-Explain
+MANEOF
+  echo "Generated man page using template: $OUTPUT"
+fi


### PR DESCRIPTION
Adds two documentation improvements for the CLI:

- **Man page generation** (Closes #621): A  script that creates a Unix man page using `help2man` or a template fallback. The man directory is included in the npm package via `files` in package.json.
- **Next.js CI integration guide** (Closes #620): A markdown guide at `packages/cli/docs/nextjs-integration.md` explaining how to use `stellar-explain` in CI pipelines (GitHub Actions, GitLab CI) for transaction validation during deployment.