### PR TITLE
fix(ci): stop Keep Backend Alive hard-failing on Render cold starts

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -21,7 +21,12 @@ jobs:
       - name: Ping backend health endpoint
         run: |
           echo "Pinging ${{ vars.BACKEND_URL }}/health ..."
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "${{ vars.BACKEND_URL }}/health")
+          # Render free-tier instances spin down after ~15 min idle and can take
+          # well over 10s to cold-start; give curl enough time to wait that out.
+          # curl already reports "000" via -w on any connection failure/timeout;
+          # `|| true` just stops that non-zero curl exit from aborting the script
+          # under `bash -e` before the warning below runs.
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 "${{ vars.BACKEND_URL }}/health" || true)
           echo "Response: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "Warning: health check returned $STATUS"


### PR DESCRIPTION
## Summary
`Keep Backend Alive` has been failing on essentially every run (`curl` exit 28, timeout), even though the script's own `if/else` was clearly written to just print a warning on a non-200 response, not fail the job.

Root cause:
- GitHub silently throttles frequent cron schedules on low-activity repos — actual runs have been landing roughly 45–60 min apart rather than every 5 min as configured.
- That's long enough for the Render free-tier instance to spin down between pings, so each ping has to cold-start it, which routinely takes longer than the existing `--max-time 10`.
- The step runs under `bash -e`, so `curl`'s non-zero exit on that timeout aborts the script immediately — before it ever reaches the "print a warning" logic — turning an intentional soft-warning path into a hard job failure every time.

Fix:
- Bumped `--max-time` to `60` so a cold start has room to actually finish.
- Added `|| true` after the `curl` call so a timeout no longer aborts the script under `bash -e`. `curl` already reports `"000"` via `-w` on any connection failure, so the existing warning logic still does the right thing for a real outage — it just no longer crashes the job for an ordinary cold start.

## Test plan
- [x] Ran the updated script locally against the real backend URL — resolves to `200`, prints "Backend is alive"
- [x] Ran the updated script locally against an unreachable host with a short timeout — prints `Response: 000` / the intended warning, and the script reaches its end with exit 0 instead of aborting